### PR TITLE
add back call to indexedToReadable() so that charsRef gets populated

### DIFF
--- a/src/main/java/org/apache/solr/request/DocValuesFacets.java
+++ b/src/main/java/org/apache/solr/request/DocValuesFacets.java
@@ -210,6 +210,7 @@ public class DocValuesFacets {
           int c = (int)(pair >>> 32);
           int tnum = Integer.MAX_VALUE - (int)pair;
           final BytesRef term = si.lookupOrd(startTermIndex+tnum);
+          ft.indexedToReadable(term, charsRef);
           if (!(extend && addEntry(searcher, fieldName, (FieldType & FacetPayload)ft, charsRef, term, res, c))) {
             res.add(charsRef.toString(), c);
           }


### PR DESCRIPTION
I think this line got mistakenly removed--in a few other similar modifications to this class, the calls to addEntry() are preceded by a call to ft.indexedToReadable().

This fixes a bug where the "termKey" passed to FacetPayload.addEntry() doesn't actually contain a term; it's always a blank string.
