### PR TITLE
normalized, filing and prefix token types

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ You'll need to set up a fieldType definition in the schema.xml file:
 <fieldType name="xfacet" class="edu.upenn.library.solrplugins.CaseInsensitiveSortingTextField" payloadHandler="edu.upenn.library.solrplugins.JsonReferencePayloadHandler" sortMissingLast="true" omitNorms="true">
   <analyzer>
     <tokenizer class="edu.upenn.library.solrplugins.JsonReferencePayloadTokenizerFactory"/>
+    <filter class="edu.upenn.library.solrplugins.tokentype.TokenTypeJoinFilterFactory" inputTypes="normalized,filing,prefix" outputType="combined" typeForPayload="normalized" />
   </analyzer>
 </fieldType>
 ```

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ You'll need to set up a fieldType definition in the schema.xml file:
 <fieldType name="xfacet" class="edu.upenn.library.solrplugins.CaseInsensitiveSortingTextField" payloadHandler="edu.upenn.library.solrplugins.JsonReferencePayloadHandler" sortMissingLast="true" omitNorms="true">
   <analyzer>
     <tokenizer class="edu.upenn.library.solrplugins.JsonReferencePayloadTokenizerFactory"/>
+    <!-- use SplitFilter to create 'normalized' token based on 'filing' token -->
+    <filter class="edu.upenn.library.solrplugins.tokentype.TokenTypeSplitFilterFactory" includeTypes="filing" outputType="normalized" _class="org.apache.lucene.analysis.icu.ICUFoldingFilterFactory" />
     <filter class="edu.upenn.library.solrplugins.tokentype.TokenTypeJoinFilterFactory" inputTypes="normalized,filing,prefix" outputType="combined" typeForPayload="normalized" />
   </analyzer>
 </fieldType>

--- a/src/main/java/edu/upenn/library/solrplugins/JsonReferencePayloadHandler.java
+++ b/src/main/java/edu/upenn/library/solrplugins/JsonReferencePayloadHandler.java
@@ -108,15 +108,15 @@ public class JsonReferencePayloadHandler implements FacetPayload<NamedList<Objec
    * Updates the Long value for the specified key in the 'preExisting' NamedList
    * by adding the value from the 'add' NamedList.
    */
-  private static void mergeCount(NamedList<Object> preExisting, NamedList<Object> add, String key) {
+  private static void mergeCount(NamedList<Object> from, NamedList<Object> to, String key) {
     // merge count
     long existingCount = 0;
-    int indexOfCount = preExisting.indexOf(key, 0);
+    int indexOfCount = to.indexOf(key, 0);
     if(indexOfCount != -1) {
-      existingCount = ((Number) preExisting.get(key)).longValue();
+      existingCount = ((Number) to.get(key)).longValue();
     }
-    long newCount = existingCount + ((Number) add.get(key)).longValue();
-    overwriteInNamedList(preExisting, key, newCount);
+    long newCount = existingCount + ((Number) from.get(key)).longValue();
+    overwriteInNamedList(to, key, newCount);
   }
 
   @Override
@@ -215,10 +215,10 @@ public class JsonReferencePayloadHandler implements FacetPayload<NamedList<Objec
 
       NamedList<Object> preExistingSelf = getOrCreateNamedListValue(preExisting, KEY_SELF);
 
-      mergeCount(preExistingSelf, addSelf, KEY_COUNT);
+      mergeCount(addSelf, preExistingSelf, KEY_COUNT);
 
-      copyFieldInNamedList(preExistingSelf, addSelf, KEY_FILING);
-      copyFieldInNamedList(preExistingSelf, addSelf, KEY_PREFIX);
+      copyFieldInNamedList(addSelf, preExistingSelf, KEY_FILING);
+      copyFieldInNamedList(addSelf, preExistingSelf, KEY_PREFIX);
     }
 
     if(add.get(KEY_REFS) != null) {
@@ -245,7 +245,7 @@ public class JsonReferencePayloadHandler implements FacetPayload<NamedList<Objec
           // if name doesn't exist in preExisting yet, create it
           NamedList<Object> preExistingNameStruct = getOrCreateNamedListValue(preExistingNameStructs, name);
 
-          mergeCount(preExistingNameStruct, addNameStruct, KEY_COUNT);
+          mergeCount(addNameStruct, preExistingNameStruct, KEY_COUNT);
 
           copyFieldInNamedList(addNameStruct, preExistingNameStruct, KEY_FILING);
           copyFieldInNamedList(addNameStruct, preExistingNameStruct, KEY_PREFIX);

--- a/src/main/java/edu/upenn/library/solrplugins/JsonReferencePayloadHandler.java
+++ b/src/main/java/edu/upenn/library/solrplugins/JsonReferencePayloadHandler.java
@@ -20,8 +20,10 @@ import org.apache.solr.request.FacetPayload;
  * <lst name="subject_xfacet">
  *   <lst name="Hegelianism">
  *     <int name="count">3</int>
- *     <str name="prefix"></str>
- *     <str name="filing">Hegelianism</str>
+ *     <lst name="self">
+ *       <long name="count">2</long>
+ *       <str name="filing">Hegelianism</str>
+ *     </lst>
  *     <lst name="refs">
  *       <lst name="see_also">
  *         <lst name="Georg Wilhelm Friedrich Hegel">

--- a/src/main/java/edu/upenn/library/solrplugins/JsonReferencePayloadTokenizer.java
+++ b/src/main/java/edu/upenn/library/solrplugins/JsonReferencePayloadTokenizer.java
@@ -210,4 +210,13 @@ public final class JsonReferencePayloadTokenizer extends Tokenizer {
     return false;
   }
 
+  @Override
+  public void reset() throws IOException {
+    super.reset();
+    consumed = false;
+    parser = null;
+    tokens.clear();
+    tokensIter = null;
+  }
+
 }

--- a/src/main/java/edu/upenn/library/solrplugins/MultiPartString.java
+++ b/src/main/java/edu/upenn/library/solrplugins/MultiPartString.java
@@ -52,21 +52,38 @@ public class MultiPartString {
     return (prefix != null ? prefix : "") + (filing != null ? filing : "");
   }
 
-  public static MultiPartString parse(String s) {
+  /**
+   * prefix is optionally present
+   */
+  public static MultiPartString parseNormalizedFilingAndPrefix(String s) {
     String[] parts = s.split(DELIMITER);
     String normalized = parts[0];
     String filing = parts[1];
-    String prefix = "";
+    String prefix = null;
     if(parts.length > 2) {
       prefix = parts[2];
     }
     return new MultiPartString(normalized, filing, prefix);
   }
 
-  public String toDelimitedString() {
+  /**
+   * prefix is optionally present
+   */
+  public static MultiPartString parseFilingAndPrefix(String s) {
+    String[] parts = s.split(DELIMITER);
+    String filing = parts[0];
+    String prefix = null;
+    if(parts.length > 1) {
+      prefix = parts[1];
+    }
+    return new MultiPartString(filing, prefix);
+  }
+
+  /**
+   * prefix is only included if present
+   */
+  public String toDelimitedStringForFilingAndPrefix() {
     StringBuilder b = new StringBuilder();
-    b.append(normalized);
-    b.append(DELIMITER);
     b.append(filing);
     if(prefix != null) {
       b.append(DELIMITER);

--- a/src/main/java/edu/upenn/library/solrplugins/MultiPartString.java
+++ b/src/main/java/edu/upenn/library/solrplugins/MultiPartString.java
@@ -1,0 +1,78 @@
+package edu.upenn.library.solrplugins;
+
+/**
+ * Strings of form:
+ *
+ *   normalized + DELIMITER + filing + DELIMITER + prefix
+ *
+ * This makes sorting on the normalized form possible,
+ * while preserving the original string (which is the prefix + filing).
+ * Note that the last pair of DELIMITER + prefix is optional.
+ *
+ * @author jeffchiu
+ */
+public class MultiPartString {
+  public static final String DELIMITER = "\u0000";
+  private String normalized;
+  private String filing;
+  private String prefix;
+
+  public MultiPartString(String normalized, String filing, String prefix) {
+    this.normalized = normalized;
+    this.filing = filing;
+    this.prefix = prefix;
+  }
+
+  public MultiPartString(String filing, String prefix) {
+    this.filing = filing;
+    this.prefix = prefix;
+  }
+
+  public MultiPartString(String filing) {
+    this.filing = filing;
+  }
+
+  public String getNormalized() {
+    return normalized;
+  }
+
+  public void setNormalized(String normalized) {
+    this.normalized = normalized;
+  }
+
+  public String getFiling() {
+    return filing;
+  }
+
+  public String getPrefix() {
+    return prefix;
+  }
+
+  public String getDisplay() {
+    return (prefix != null ? prefix : "") + (filing != null ? filing : "");
+  }
+
+  public static MultiPartString parse(String s) {
+    String[] parts = s.split(DELIMITER);
+    String normalized = parts[0];
+    String filing = parts[1];
+    String prefix = "";
+    if(parts.length > 2) {
+      prefix = parts[2];
+    }
+    return new MultiPartString(normalized, filing, prefix);
+  }
+
+  public String toDelimitedString() {
+    StringBuilder b = new StringBuilder();
+    b.append(normalized);
+    b.append(DELIMITER);
+    b.append(filing);
+    if(prefix != null) {
+      b.append(DELIMITER);
+      b.append(prefix);
+    }
+    return b.toString();
+  }
+
+}

--- a/src/main/java/edu/upenn/library/solrplugins/tokentype/TokenTypeJoinFilter.java
+++ b/src/main/java/edu/upenn/library/solrplugins/tokentype/TokenTypeJoinFilter.java
@@ -164,9 +164,7 @@ public final class TokenTypeJoinFilter extends TokenFilter {
     if (outputComponentTokens) {
       posIncrAtt.setPositionIncrement(0);
     }
-    if(payload != null) {
-      payloadAtt.setPayload(payload);
-    }
+    payloadAtt.setPayload(payload);
     Arrays.fill(components, null);
     primed = false;
   }

--- a/src/main/java/edu/upenn/library/solrplugins/tokentype/TokenTypeJoinFilter.java
+++ b/src/main/java/edu/upenn/library/solrplugins/tokentype/TokenTypeJoinFilter.java
@@ -23,8 +23,10 @@ import org.apache.lucene.analysis.TokenFilter;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
 import org.apache.lucene.analysis.tokenattributes.OffsetAttribute;
+import org.apache.lucene.analysis.tokenattributes.PayloadAttribute;
 import org.apache.lucene.analysis.tokenattributes.PositionIncrementAttribute;
 import org.apache.lucene.analysis.tokenattributes.TypeAttribute;
+import org.apache.lucene.util.BytesRef;
 
 /**
  *
@@ -36,9 +38,11 @@ public final class TokenTypeJoinFilter extends TokenFilter {
   private final PositionIncrementAttribute posIncrAtt = addAttribute(PositionIncrementAttribute.class);
   private final TypeAttribute typeAtt = addAttribute(TypeAttribute.class);
   private final OffsetAttribute offsetAtt = addAttribute(OffsetAttribute.class);
+  private final PayloadAttribute payloadAtt = addAttribute(PayloadAttribute.class);
 
   private final StringBuilder sb = new StringBuilder(200);
   private final String outputType;
+  private final String typeForPayload;
   private final String delim;
   private final boolean outputComponentTokens;
   private final boolean appendPlaceholders;
@@ -47,13 +51,14 @@ public final class TokenTypeJoinFilter extends TokenFilter {
   private final String[] components;
   private int bufferedOffsetStart;
   private int bufferedOffsetEnd;
+  private BytesRef payload;
   private State state;
   private boolean primed = false;
   private boolean exhausted = false;
   private int increment = 0;
 
-  public TokenTypeJoinFilter(TokenStream input, String[] componentTypes, String outputType, String delim,
-      boolean outputComponentTokens, boolean appendPlaceholders) {
+  public TokenTypeJoinFilter(TokenStream input, String[] componentTypes, String outputType, String typeForPayload,
+      String delim, boolean outputComponentTokens, boolean appendPlaceholders) {
     super(input);
     componentIndexMap = new HashMap<>(componentTypes.length * 2);
     for (int i = 0; i < componentTypes.length; i++) {
@@ -61,6 +66,7 @@ public final class TokenTypeJoinFilter extends TokenFilter {
     }
     components = new String[componentTypes.length];
     this.outputType = outputType;
+    this.typeForPayload = typeForPayload;
     this.delim = delim;
     this.outputComponentTokens = outputComponentTokens;
     this.appendPlaceholders = appendPlaceholders;
@@ -98,6 +104,16 @@ public final class TokenTypeJoinFilter extends TokenFilter {
     }
   }
 
+  /**
+   * Stores current token's payload attribute in a member variable
+   * if it's appropriate to do so.
+   */
+  private void storePayload() {
+    if(typeForPayload != null && payload == null && typeForPayload.equals(typeAtt.type())) {
+      payload = payloadAtt.getPayload();
+    }
+  }
+
   private boolean buffer() throws IOException {
     Integer index;
     if ((index = componentIndexMap.get(typeAtt.type())) != null) {
@@ -113,12 +129,15 @@ public final class TokenTypeJoinFilter extends TokenFilter {
       } else {
         bufferedOffsetStart = offsetAtt.startOffset();
         bufferedOffsetEnd = offsetAtt.endOffset();
+        payload = null;
         primed = true;
       }
+      storePayload();
       return outputComponentTokens || incrementToken();
     } else {
       posIncrAtt.setPositionIncrement(increment);
       increment = 0;
+      storePayload();
       return true;
     }
   }
@@ -144,6 +163,9 @@ public final class TokenTypeJoinFilter extends TokenFilter {
     offsetAtt.setOffset(bufferedOffsetStart, bufferedOffsetEnd);
     if (outputComponentTokens) {
       posIncrAtt.setPositionIncrement(0);
+    }
+    if(payload != null) {
+      payloadAtt.setPayload(payload);
     }
     Arrays.fill(components, null);
     primed = false;

--- a/src/main/java/edu/upenn/library/solrplugins/tokentype/TokenTypeJoinFilterFactory.java
+++ b/src/main/java/edu/upenn/library/solrplugins/tokentype/TokenTypeJoinFilterFactory.java
@@ -32,6 +32,7 @@ public class TokenTypeJoinFilterFactory extends TokenFilterFactory {
   private static final String DELIM_CODEPOINT_ARGNAME = "delimCodepoint";
   private static final String HIERARCHY_LEVEL_ARGNAME = "hierarchyLevel";
   private static final String OUTPUT_TYPE_ARGNAME = "outputType";
+  private static final String TYPE_FOR_PAYLOAD_ARGNAME = "typeForPayload";
   private static final String OUTPUT_COMPONENTS_ARGNAME = "outputComponents";
   private static final String APPEND_PLACEHOLDERS_ARGNAME = "appendPlaceholders";
   private static final boolean DEFAULT_OUTPUT_COMPONENTS = false;
@@ -42,6 +43,7 @@ public class TokenTypeJoinFilterFactory extends TokenFilterFactory {
 
   private final String[] inputTypes;
   private final String outputType;
+  private final String typeForPayload;
   private final String delim;
   private final boolean outputComponents;
   private final boolean appendPlaceholders;
@@ -59,6 +61,7 @@ public class TokenTypeJoinFilterFactory extends TokenFilterFactory {
     }
     inputTypes = args.get(INPUT_TYPES_ARGNAME).split("\\s*,\\s*");
     outputType = args.get(OUTPUT_TYPE_ARGNAME);
+    typeForPayload = args.get(TYPE_FOR_PAYLOAD_ARGNAME);
     String outputComponentsS = args.get(OUTPUT_COMPONENTS_ARGNAME);
     this.outputComponents = outputComponentsS == null ? DEFAULT_OUTPUT_COMPONENTS : Boolean.parseBoolean(outputComponentsS);
     String appendPlaceholdersS = args.get(APPEND_PLACEHOLDERS_ARGNAME);
@@ -67,7 +70,7 @@ public class TokenTypeJoinFilterFactory extends TokenFilterFactory {
 
   @Override
   public TokenStream create(TokenStream input) {
-    return new TokenTypeJoinFilter(input, inputTypes, outputType, delim, outputComponents, appendPlaceholders);
+    return new TokenTypeJoinFilter(input, inputTypes, outputType, typeForPayload, delim, outputComponents, appendPlaceholders);
   }
 
 }

--- a/src/test/java/edu/upenn/library/solrplugins/JsonReferencePayloadHandlerTest.java
+++ b/src/test/java/edu/upenn/library/solrplugins/JsonReferencePayloadHandlerTest.java
@@ -12,13 +12,11 @@ public class JsonReferencePayloadHandlerTest {
 
     NamedList<Object> preGHegelStruct = new NamedList<>();
     preGHegelStruct.add("count", 2L);
-    preGHegelStruct.add("normalized", "hegel");
     preGHegelStruct.add("prefix", "G. ");
     preGHegelStruct.add("filing", "Hegel");
 
     NamedList<Object> preGeorgHegelStruct = new NamedList<>();
     preGeorgHegelStruct.add("count", 3L);
-    preGeorgHegelStruct.add("normalized", "hegel2");
     preGeorgHegelStruct.add("prefix", "Georg ");
     preGeorgHegelStruct.add("filing", "Hegel2");
 
@@ -37,13 +35,11 @@ public class JsonReferencePayloadHandlerTest {
 
     NamedList<Object> addGHegelStruct = new NamedList<>();
     addGHegelStruct.add("count", 4L);
-    addGHegelStruct.add("normalized", "hegel");
     addGHegelStruct.add("prefix", "G. ");
     addGHegelStruct.add("filing", "Hegel");
 
     NamedList<Object> addHegelStruct = new NamedList<>();
     addHegelStruct.add("count", 1L);
-    addHegelStruct.add("normalized", "hegel3");
     addHegelStruct.add("filing", "Hegel3");
 
     NamedList<Object> addUseForNameStructs = new NamedList<>();
@@ -52,7 +48,6 @@ public class JsonReferencePayloadHandlerTest {
 
     NamedList<Object> addGWFHegelStruct = new NamedList<>();
     addGWFHegelStruct.add("count", 4L);
-    addGWFHegelStruct.add("normalized", "hegel");
     addGWFHegelStruct.add("prefix", "G. W. F. ");
     addGWFHegelStruct.add("filing", "Hegel");
 
@@ -82,19 +77,16 @@ public class JsonReferencePayloadHandlerTest {
 
     NamedList<Object> useFor1 = (NamedList<Object>) useForNameStructs.get("G. Hegel");
     assertEquals(6L, useFor1.get("count"));
-    assertEquals("hegel", useFor1.get("normalized"));
     assertEquals("G. ", useFor1.get("prefix"));
     assertEquals("Hegel", useFor1.get("filing"));
 
     NamedList<Object> useFor2 = (NamedList<Object>) useForNameStructs.get("Georg Hegel2");
     assertEquals(3L, useFor2.get("count"));
-    assertEquals("hegel2", useFor2.get("normalized"));
     assertEquals("Georg ", useFor2.get("prefix"));
     assertEquals("Hegel2", useFor2.get("filing"));
 
     NamedList<Object> useFor3 = (NamedList<Object>) useForNameStructs.get("Hegel3");
     assertEquals(1L, useFor3.get("count"));
-    assertEquals("hegel3", useFor3.get("normalized"));
     assertEquals("Hegel3", useFor3.get("filing"));
 
     NamedList<Object> seeAlsoNameStructs = (NamedList<Object>) mergedRefs.get("see_also");
@@ -104,7 +96,6 @@ public class JsonReferencePayloadHandlerTest {
     NamedList<Object> seeAlso1 = (NamedList<Object>) seeAlsoNameStructs.get("G. W. F. Hegel");
 
     assertEquals(4L, seeAlso1.get("count"));
-    assertEquals("hegel", seeAlso1.get("normalized"));
     assertEquals("G. W. F. ", seeAlso1.get("prefix"));
     assertEquals("Hegel", seeAlso1.get("filing"));
   }

--- a/src/test/java/edu/upenn/library/solrplugins/JsonReferencePayloadHandlerTest.java
+++ b/src/test/java/edu/upenn/library/solrplugins/JsonReferencePayloadHandlerTest.java
@@ -8,31 +8,66 @@ public class JsonReferencePayloadHandlerTest {
 
   @Test
   public void testMergePayload() {
-    NamedList<Object> preUseForTargetCounts = new NamedList<>();
-    preUseForTargetCounts.add("G. Hegel", 2L);
-    preUseForTargetCounts.add("Georg Hegel", 3L);
+    // build data for preExisting record
+
+    NamedList<Object> preGHegelStruct = new NamedList<>();
+    preGHegelStruct.add("count", 2L);
+    preGHegelStruct.add("normalized", "hegel");
+    preGHegelStruct.add("prefix", "G. ");
+    preGHegelStruct.add("filing", "Hegel");
+
+    NamedList<Object> preGeorgHegelStruct = new NamedList<>();
+    preGeorgHegelStruct.add("count", 3L);
+    preGeorgHegelStruct.add("normalized", "hegel2");
+    preGeorgHegelStruct.add("prefix", "Georg ");
+    preGeorgHegelStruct.add("filing", "Hegel2");
+
+    NamedList<Object> preUseForNameStructs = new NamedList<>();
+    preUseForNameStructs.add("G. Hegel", preGHegelStruct);
+    preUseForNameStructs.add("Georg Hegel2", preGeorgHegelStruct);
 
     NamedList<Object> preRefs = new NamedList<>();
-    preRefs.add("use_for", preUseForTargetCounts);
+    preRefs.add("use_for", preUseForNameStructs);
 
     NamedList<Object> preExisting = new NamedList<>();
     preExisting.add("count", 10L);
     preExisting.add("refs", preRefs);
 
-    NamedList<Object> addUseForTargetCounts = new NamedList<>();
-    addUseForTargetCounts.add("G. Hegel", 4L);
-    addUseForTargetCounts.add("Hegel", 1L);
+    // build data for record to add/merge
 
-    NamedList<Object> addSeeAlsoTargetCounts = new NamedList<>();
-    addSeeAlsoTargetCounts.add("G. W. F. Hegel", 4L);
+    NamedList<Object> addGHegelStruct = new NamedList<>();
+    addGHegelStruct.add("count", 4L);
+    addGHegelStruct.add("normalized", "hegel");
+    addGHegelStruct.add("prefix", "G. ");
+    addGHegelStruct.add("filing", "Hegel");
+
+    NamedList<Object> addHegelStruct = new NamedList<>();
+    addHegelStruct.add("count", 1L);
+    addHegelStruct.add("normalized", "hegel3");
+    addHegelStruct.add("filing", "Hegel3");
+
+    NamedList<Object> addUseForNameStructs = new NamedList<>();
+    addUseForNameStructs.add("G. Hegel", addGHegelStruct);
+    addUseForNameStructs.add("Hegel3", addHegelStruct);
+
+    NamedList<Object> addGWFHegelStruct = new NamedList<>();
+    addGWFHegelStruct.add("count", 4L);
+    addGWFHegelStruct.add("normalized", "hegel");
+    addGWFHegelStruct.add("prefix", "G. W. F. ");
+    addGWFHegelStruct.add("filing", "Hegel");
+
+    NamedList<Object> addSeeAlsoNameStructs = new NamedList<>();
+    addSeeAlsoNameStructs.add("G. W. F. Hegel", addGWFHegelStruct);
 
     NamedList<Object> addRefs = new NamedList<>();
-    addRefs.add("use_for", addUseForTargetCounts);
-    addRefs.add("see_also", addSeeAlsoTargetCounts);
+    addRefs.add("use_for", addUseForNameStructs);
+    addRefs.add("see_also", addSeeAlsoNameStructs);
 
     NamedList<Object> add = new NamedList<>();
     add.add("count", 4L);
     add.add("refs", addRefs);
+
+    // test merge
 
     JsonReferencePayloadHandler handler = new JsonReferencePayloadHandler();
 
@@ -41,19 +76,37 @@ public class JsonReferencePayloadHandlerTest {
     assertEquals(14L, result.get("count"));
 
     NamedList<Object> mergedRefs = (NamedList<Object>) result.get("refs");
-    NamedList<Object> useForTargetCounts = (NamedList<Object>) mergedRefs.get("use_for");
+    NamedList<Object> useForNameStructs = (NamedList<Object>) mergedRefs.get("use_for");
 
-    assertEquals(3, useForTargetCounts.size());
+    assertEquals(3, useForNameStructs.size());
 
-    assertEquals(6L, useForTargetCounts.get("G. Hegel"));
-    assertEquals(3L, useForTargetCounts.get("Georg Hegel"));
-    assertEquals(1L, useForTargetCounts.get("Hegel"));
+    NamedList<Object> useFor1 = (NamedList<Object>) useForNameStructs.get("G. Hegel");
+    assertEquals(6L, useFor1.get("count"));
+    assertEquals("hegel", useFor1.get("normalized"));
+    assertEquals("G. ", useFor1.get("prefix"));
+    assertEquals("Hegel", useFor1.get("filing"));
 
-    NamedList<Object> seeAlsoTargetCounts = (NamedList<Object>) mergedRefs.get("see_also");
+    NamedList<Object> useFor2 = (NamedList<Object>) useForNameStructs.get("Georg Hegel2");
+    assertEquals(3L, useFor2.get("count"));
+    assertEquals("hegel2", useFor2.get("normalized"));
+    assertEquals("Georg ", useFor2.get("prefix"));
+    assertEquals("Hegel2", useFor2.get("filing"));
 
-    assertEquals(1, seeAlsoTargetCounts.size());
+    NamedList<Object> useFor3 = (NamedList<Object>) useForNameStructs.get("Hegel3");
+    assertEquals(1L, useFor3.get("count"));
+    assertEquals("hegel3", useFor3.get("normalized"));
+    assertEquals("Hegel3", useFor3.get("filing"));
 
-    assertEquals(4L, seeAlsoTargetCounts.get("G. W. F. Hegel"));
+    NamedList<Object> seeAlsoNameStructs = (NamedList<Object>) mergedRefs.get("see_also");
+
+    assertEquals(1, seeAlsoNameStructs.size());
+
+    NamedList<Object> seeAlso1 = (NamedList<Object>) seeAlsoNameStructs.get("G. W. F. Hegel");
+
+    assertEquals(4L, seeAlso1.get("count"));
+    assertEquals("hegel", seeAlso1.get("normalized"));
+    assertEquals("G. W. F. ", seeAlso1.get("prefix"));
+    assertEquals("Hegel", seeAlso1.get("filing"));
   }
 
 }

--- a/src/test/java/edu/upenn/library/solrplugins/JsonReferencePayloadHandlerTest.java
+++ b/src/test/java/edu/upenn/library/solrplugins/JsonReferencePayloadHandlerTest.java
@@ -12,9 +12,12 @@ public class JsonReferencePayloadHandlerTest {
     preUseForTargetCounts.add("G. Hegel", 2L);
     preUseForTargetCounts.add("Georg Hegel", 3L);
 
+    NamedList<Object> preRefs = new NamedList<>();
+    preRefs.add("use_for", preUseForTargetCounts);
+
     NamedList<Object> preExisting = new NamedList<>();
     preExisting.add("count", 10L);
-    preExisting.add("use_for", preUseForTargetCounts);
+    preExisting.add("refs", preRefs);
 
     NamedList<Object> addUseForTargetCounts = new NamedList<>();
     addUseForTargetCounts.add("G. Hegel", 4L);
@@ -23,10 +26,13 @@ public class JsonReferencePayloadHandlerTest {
     NamedList<Object> addSeeAlsoTargetCounts = new NamedList<>();
     addSeeAlsoTargetCounts.add("G. W. F. Hegel", 4L);
 
+    NamedList<Object> addRefs = new NamedList<>();
+    addRefs.add("use_for", addUseForTargetCounts);
+    addRefs.add("see_also", addSeeAlsoTargetCounts);
+
     NamedList<Object> add = new NamedList<>();
     add.add("count", 4L);
-    add.add("use_for", addUseForTargetCounts);
-    add.add("see_also", addSeeAlsoTargetCounts);
+    add.add("refs", addRefs);
 
     JsonReferencePayloadHandler handler = new JsonReferencePayloadHandler();
 
@@ -34,7 +40,8 @@ public class JsonReferencePayloadHandlerTest {
 
     assertEquals(14L, result.get("count"));
 
-    NamedList<Object> useForTargetCounts = (NamedList<Object>) result.get("use_for");
+    NamedList<Object> mergedRefs = (NamedList<Object>) result.get("refs");
+    NamedList<Object> useForTargetCounts = (NamedList<Object>) mergedRefs.get("use_for");
 
     assertEquals(3, useForTargetCounts.size());
 
@@ -42,7 +49,7 @@ public class JsonReferencePayloadHandlerTest {
     assertEquals(3L, useForTargetCounts.get("Georg Hegel"));
     assertEquals(1L, useForTargetCounts.get("Hegel"));
 
-    NamedList<Object> seeAlsoTargetCounts = (NamedList<Object>) result.get("see_also");
+    NamedList<Object> seeAlsoTargetCounts = (NamedList<Object>) mergedRefs.get("see_also");
 
     assertEquals(1, seeAlsoTargetCounts.size());
 

--- a/src/test/java/edu/upenn/library/solrplugins/JsonReferencePayloadHandlerTest.java
+++ b/src/test/java/edu/upenn/library/solrplugins/JsonReferencePayloadHandlerTest.java
@@ -27,9 +27,14 @@ public class JsonReferencePayloadHandlerTest {
     NamedList<Object> preRefs = new NamedList<>();
     preRefs.add("use_for", preUseForNameStructs);
 
+    NamedList<Object> preSelf = new NamedList<>();
+    preSelf.add("count", 4L);
+    preSelf.add("filing", "Hegel");
+
     NamedList<Object> preExisting = new NamedList<>();
-    preExisting.add("count", 10L);
+    preExisting.add("count", 9L);
     preExisting.add("refs", preRefs);
+    preExisting.add("self", preSelf);
 
     // build data for record to add/merge
 
@@ -58,17 +63,26 @@ public class JsonReferencePayloadHandlerTest {
     addRefs.add("use_for", addUseForNameStructs);
     addRefs.add("see_also", addSeeAlsoNameStructs);
 
+    NamedList<Object> addSelf = new NamedList<>();
+    addSelf.add("count", 3L);
+    addSelf.add("filing", "Hegel");
+
     NamedList<Object> add = new NamedList<>();
-    add.add("count", 4L);
+    add.add("count", 12L);
     add.add("refs", addRefs);
+    add.add("self", addSelf);
 
     // test merge
 
     JsonReferencePayloadHandler handler = new JsonReferencePayloadHandler();
 
-    NamedList<Object> result = (NamedList<Object>) handler.mergePayload(preExisting, add, 10L, 4L);
+    NamedList<Object> result = (NamedList<Object>) handler.mergePayload(preExisting, add, 9L, 12L);
 
-    assertEquals(14L, result.get("count"));
+    assertEquals(21L, result.get("count"));
+
+    NamedList<Object> self = (NamedList<Object>) result.get("self");
+    assertEquals(7L, self.get("count"));
+    assertEquals("Hegel", self.get("filing"));
 
     NamedList<Object> mergedRefs = (NamedList<Object>) result.get("refs");
     NamedList<Object> useForNameStructs = (NamedList<Object>) mergedRefs.get("use_for");

--- a/src/test/java/edu/upenn/library/solrplugins/JsonReferencePayloadTokenizerTest.java
+++ b/src/test/java/edu/upenn/library/solrplugins/JsonReferencePayloadTokenizerTest.java
@@ -36,37 +36,37 @@ public class JsonReferencePayloadTokenizerTest {
     assertEquals("ref1", tokenizer.getAttribute(CharTermAttribute.class).toString());
     assertEquals(JsonReferencePayloadTokenizer.TYPE_NORMALIZED, tokenizer.getAttribute(TypeAttribute.class).type());
     assertEquals(2, tokenizer.getAttribute(PositionIncrementAttribute.class).getPositionIncrement());
-    assertEquals("use_for" + JsonReferencePayloadTokenizer.PAYLOAD_ATTR_SEPARATOR + "some value", tokenizer.getAttribute(PayloadAttribute.class).getPayload().utf8ToString());
+    assertEquals("use_for" + JsonReferencePayloadTokenizer.PAYLOAD_ATTR_SEPARATOR + "some value" + MultiPartString.DELIMITER + "some value", tokenizer.getAttribute(PayloadAttribute.class).getPayload().utf8ToString());
 
     assertTrue(tokenizer.incrementToken());
     assertEquals("ref1", tokenizer.getAttribute(CharTermAttribute.class).toString());
     assertEquals(JsonReferencePayloadTokenizer.TYPE_FILING, tokenizer.getAttribute(TypeAttribute.class).type());
     assertEquals(0, tokenizer.getAttribute(PositionIncrementAttribute.class).getPositionIncrement());
-    assertEquals("use_for" + JsonReferencePayloadTokenizer.PAYLOAD_ATTR_SEPARATOR + "some value", tokenizer.getAttribute(PayloadAttribute.class).getPayload().utf8ToString());
+    assertEquals("use_for" + JsonReferencePayloadTokenizer.PAYLOAD_ATTR_SEPARATOR + "some value" + MultiPartString.DELIMITER + "some value", tokenizer.getAttribute(PayloadAttribute.class).getPayload().utf8ToString());
 
     assertTrue(tokenizer.incrementToken());
     assertEquals("ref2", tokenizer.getAttribute(CharTermAttribute.class).toString());
     assertEquals(JsonReferencePayloadTokenizer.TYPE_NORMALIZED, tokenizer.getAttribute(TypeAttribute.class).type());
     assertEquals(3, tokenizer.getAttribute(PositionIncrementAttribute.class).getPositionIncrement());
-    assertEquals("use_for" + JsonReferencePayloadTokenizer.PAYLOAD_ATTR_SEPARATOR + "some value", tokenizer.getAttribute(PayloadAttribute.class).getPayload().utf8ToString());
+    assertEquals("use_for" + JsonReferencePayloadTokenizer.PAYLOAD_ATTR_SEPARATOR + "some value" + MultiPartString.DELIMITER + "some value", tokenizer.getAttribute(PayloadAttribute.class).getPayload().utf8ToString());
 
     assertTrue(tokenizer.incrementToken());
     assertEquals("ref2", tokenizer.getAttribute(CharTermAttribute.class).toString());
     assertEquals(JsonReferencePayloadTokenizer.TYPE_FILING, tokenizer.getAttribute(TypeAttribute.class).type());
     assertEquals(0, tokenizer.getAttribute(PositionIncrementAttribute.class).getPositionIncrement());
-    assertEquals("use_for" + JsonReferencePayloadTokenizer.PAYLOAD_ATTR_SEPARATOR + "some value", tokenizer.getAttribute(PayloadAttribute.class).getPayload().utf8ToString());
+    assertEquals("use_for" + JsonReferencePayloadTokenizer.PAYLOAD_ATTR_SEPARATOR + "some value" + MultiPartString.DELIMITER + "some value", tokenizer.getAttribute(PayloadAttribute.class).getPayload().utf8ToString());
 
     assertTrue(tokenizer.incrementToken());
     assertEquals("ref3", tokenizer.getAttribute(CharTermAttribute.class).toString());
     assertEquals(JsonReferencePayloadTokenizer.TYPE_NORMALIZED, tokenizer.getAttribute(TypeAttribute.class).type());
     assertEquals(4, tokenizer.getAttribute(PositionIncrementAttribute.class).getPositionIncrement());
-    assertEquals("see_also" + JsonReferencePayloadTokenizer.PAYLOAD_ATTR_SEPARATOR + "some value", tokenizer.getAttribute(PayloadAttribute.class).getPayload().utf8ToString());
+    assertEquals("see_also" + JsonReferencePayloadTokenizer.PAYLOAD_ATTR_SEPARATOR + "some value" + MultiPartString.DELIMITER + "some value", tokenizer.getAttribute(PayloadAttribute.class).getPayload().utf8ToString());
 
     assertTrue(tokenizer.incrementToken());
     assertEquals("ref3", tokenizer.getAttribute(CharTermAttribute.class).toString());
     assertEquals(JsonReferencePayloadTokenizer.TYPE_FILING, tokenizer.getAttribute(TypeAttribute.class).type());
     assertEquals(0, tokenizer.getAttribute(PositionIncrementAttribute.class).getPositionIncrement());
-    assertEquals("see_also" + JsonReferencePayloadTokenizer.PAYLOAD_ATTR_SEPARATOR + "some value", tokenizer.getAttribute(PayloadAttribute.class).getPayload().utf8ToString());
+    assertEquals("see_also" + JsonReferencePayloadTokenizer.PAYLOAD_ATTR_SEPARATOR + "some value" + MultiPartString.DELIMITER + "some value", tokenizer.getAttribute(PayloadAttribute.class).getPayload().utf8ToString());
 
     assertFalse(tokenizer.incrementToken());
   }
@@ -99,43 +99,43 @@ public class JsonReferencePayloadTokenizerTest {
     assertEquals("ref1", tokenizer.getAttribute(CharTermAttribute.class).toString());
     assertEquals(JsonReferencePayloadTokenizer.TYPE_NORMALIZED, tokenizer.getAttribute(TypeAttribute.class).type());
     assertEquals(2, tokenizer.getAttribute(PositionIncrementAttribute.class).getPositionIncrement());
-    assertEquals("use_for" + JsonReferencePayloadTokenizer.PAYLOAD_ATTR_SEPARATOR + "the unconsoled", tokenizer.getAttribute(PayloadAttribute.class).getPayload().utf8ToString());
+    assertEquals("use_for" + JsonReferencePayloadTokenizer.PAYLOAD_ATTR_SEPARATOR + "unconsoled" + MultiPartString.DELIMITER + "unconsoled" + MultiPartString.DELIMITER + "the ", tokenizer.getAttribute(PayloadAttribute.class).getPayload().utf8ToString());
 
     assertTrue(tokenizer.incrementToken());
     assertEquals("ref1", tokenizer.getAttribute(CharTermAttribute.class).toString());
     assertEquals(JsonReferencePayloadTokenizer.TYPE_FILING, tokenizer.getAttribute(TypeAttribute.class).type());
     assertEquals(0, tokenizer.getAttribute(PositionIncrementAttribute.class).getPositionIncrement());
-    assertEquals("use_for" + JsonReferencePayloadTokenizer.PAYLOAD_ATTR_SEPARATOR + "the unconsoled", tokenizer.getAttribute(PayloadAttribute.class).getPayload().utf8ToString());
+    assertEquals("use_for" + JsonReferencePayloadTokenizer.PAYLOAD_ATTR_SEPARATOR + "unconsoled" + MultiPartString.DELIMITER + "unconsoled" + MultiPartString.DELIMITER + "the ", tokenizer.getAttribute(PayloadAttribute.class).getPayload().utf8ToString());
 
     assertTrue(tokenizer.incrementToken());
     assertEquals("chicken", tokenizer.getAttribute(CharTermAttribute.class).toString());
     assertEquals(JsonReferencePayloadTokenizer.TYPE_NORMALIZED, tokenizer.getAttribute(TypeAttribute.class).type());
     assertEquals(3, tokenizer.getAttribute(PositionIncrementAttribute.class).getPositionIncrement());
-    assertEquals("use_for" + JsonReferencePayloadTokenizer.PAYLOAD_ATTR_SEPARATOR + "the unconsoled", tokenizer.getAttribute(PayloadAttribute.class).getPayload().utf8ToString());
+    assertEquals("use_for" + JsonReferencePayloadTokenizer.PAYLOAD_ATTR_SEPARATOR + "unconsoled" + MultiPartString.DELIMITER + "unconsoled" + MultiPartString.DELIMITER + "the ", tokenizer.getAttribute(PayloadAttribute.class).getPayload().utf8ToString());
 
     assertTrue(tokenizer.incrementToken());
     assertEquals("chicken", tokenizer.getAttribute(CharTermAttribute.class).toString());
     assertEquals(JsonReferencePayloadTokenizer.TYPE_FILING, tokenizer.getAttribute(TypeAttribute.class).type());
     assertEquals(0, tokenizer.getAttribute(PositionIncrementAttribute.class).getPositionIncrement());
-    assertEquals("use_for" + JsonReferencePayloadTokenizer.PAYLOAD_ATTR_SEPARATOR + "the unconsoled", tokenizer.getAttribute(PayloadAttribute.class).getPayload().utf8ToString());
+    assertEquals("use_for" + JsonReferencePayloadTokenizer.PAYLOAD_ATTR_SEPARATOR + "unconsoled" + MultiPartString.DELIMITER + "unconsoled" + MultiPartString.DELIMITER + "the ", tokenizer.getAttribute(PayloadAttribute.class).getPayload().utf8ToString());
 
     assertTrue(tokenizer.incrementToken());
     assertEquals("a ", tokenizer.getAttribute(CharTermAttribute.class).toString());
     assertEquals(JsonReferencePayloadTokenizer.TYPE_PREFIX, tokenizer.getAttribute(TypeAttribute.class).type());
     assertEquals(0, tokenizer.getAttribute(PositionIncrementAttribute.class).getPositionIncrement());
-    assertEquals("use_for" + JsonReferencePayloadTokenizer.PAYLOAD_ATTR_SEPARATOR + "the unconsoled", tokenizer.getAttribute(PayloadAttribute.class).getPayload().utf8ToString());
+    assertEquals("use_for" + JsonReferencePayloadTokenizer.PAYLOAD_ATTR_SEPARATOR + "unconsoled" + MultiPartString.DELIMITER + "unconsoled" + MultiPartString.DELIMITER + "the ", tokenizer.getAttribute(PayloadAttribute.class).getPayload().utf8ToString());
 
     assertTrue(tokenizer.incrementToken());
     assertEquals("ref3", tokenizer.getAttribute(CharTermAttribute.class).toString());
     assertEquals(JsonReferencePayloadTokenizer.TYPE_NORMALIZED, tokenizer.getAttribute(TypeAttribute.class).type());
     assertEquals(4, tokenizer.getAttribute(PositionIncrementAttribute.class).getPositionIncrement());
-    assertEquals("see_also" + JsonReferencePayloadTokenizer.PAYLOAD_ATTR_SEPARATOR + "the unconsoled", tokenizer.getAttribute(PayloadAttribute.class).getPayload().utf8ToString());
+    assertEquals("see_also" + JsonReferencePayloadTokenizer.PAYLOAD_ATTR_SEPARATOR + "unconsoled" + MultiPartString.DELIMITER + "unconsoled" + MultiPartString.DELIMITER + "the ", tokenizer.getAttribute(PayloadAttribute.class).getPayload().utf8ToString());
 
     assertTrue(tokenizer.incrementToken());
     assertEquals("ref3", tokenizer.getAttribute(CharTermAttribute.class).toString());
     assertEquals(JsonReferencePayloadTokenizer.TYPE_FILING, tokenizer.getAttribute(TypeAttribute.class).type());
     assertEquals(0, tokenizer.getAttribute(PositionIncrementAttribute.class).getPositionIncrement());
-    assertEquals("see_also" + JsonReferencePayloadTokenizer.PAYLOAD_ATTR_SEPARATOR + "the unconsoled", tokenizer.getAttribute(PayloadAttribute.class).getPayload().utf8ToString());
+    assertEquals("see_also" + JsonReferencePayloadTokenizer.PAYLOAD_ATTR_SEPARATOR + "unconsoled" + MultiPartString.DELIMITER + "unconsoled" + MultiPartString.DELIMITER + "the ", tokenizer.getAttribute(PayloadAttribute.class).getPayload().utf8ToString());
 
     assertFalse(tokenizer.incrementToken());
   }

--- a/src/test/java/edu/upenn/library/solrplugins/JsonReferencePayloadTokenizerTest.java
+++ b/src/test/java/edu/upenn/library/solrplugins/JsonReferencePayloadTokenizerTest.java
@@ -22,51 +22,27 @@ public class JsonReferencePayloadTokenizerTest {
 
     assertTrue(tokenizer.incrementToken());
     assertEquals("some value", tokenizer.getAttribute(CharTermAttribute.class).toString());
-    assertEquals(JsonReferencePayloadTokenizer.TYPE_NORMALIZED, tokenizer.getAttribute(TypeAttribute.class).type());
+    assertEquals(JsonReferencePayloadTokenizer.TYPE_FILING, tokenizer.getAttribute(TypeAttribute.class).type());
     assertEquals(1, tokenizer.getAttribute(PositionIncrementAttribute.class).getPositionIncrement());
     assertNull(tokenizer.getAttribute(PayloadAttribute.class).getPayload());
 
     assertTrue(tokenizer.incrementToken());
-    assertEquals("some value", tokenizer.getAttribute(CharTermAttribute.class).toString());
-    assertEquals(JsonReferencePayloadTokenizer.TYPE_FILING, tokenizer.getAttribute(TypeAttribute.class).type());
-    assertEquals(0, tokenizer.getAttribute(PositionIncrementAttribute.class).getPositionIncrement());
-    assertNull(tokenizer.getAttribute(PayloadAttribute.class).getPayload());
-
-    assertTrue(tokenizer.incrementToken());
     assertEquals("ref1", tokenizer.getAttribute(CharTermAttribute.class).toString());
-    assertEquals(JsonReferencePayloadTokenizer.TYPE_NORMALIZED, tokenizer.getAttribute(TypeAttribute.class).type());
+    assertEquals(JsonReferencePayloadTokenizer.TYPE_FILING, tokenizer.getAttribute(TypeAttribute.class).type());
     assertEquals(2, tokenizer.getAttribute(PositionIncrementAttribute.class).getPositionIncrement());
-    assertEquals("use_for" + JsonReferencePayloadTokenizer.PAYLOAD_ATTR_SEPARATOR + "some value" + MultiPartString.DELIMITER + "some value", tokenizer.getAttribute(PayloadAttribute.class).getPayload().utf8ToString());
-
-    assertTrue(tokenizer.incrementToken());
-    assertEquals("ref1", tokenizer.getAttribute(CharTermAttribute.class).toString());
-    assertEquals(JsonReferencePayloadTokenizer.TYPE_FILING, tokenizer.getAttribute(TypeAttribute.class).type());
-    assertEquals(0, tokenizer.getAttribute(PositionIncrementAttribute.class).getPositionIncrement());
-    assertEquals("use_for" + JsonReferencePayloadTokenizer.PAYLOAD_ATTR_SEPARATOR + "some value" + MultiPartString.DELIMITER + "some value", tokenizer.getAttribute(PayloadAttribute.class).getPayload().utf8ToString());
+    assertEquals("use_for" + JsonReferencePayloadTokenizer.PAYLOAD_ATTR_SEPARATOR + "some value", tokenizer.getAttribute(PayloadAttribute.class).getPayload().utf8ToString());
 
     assertTrue(tokenizer.incrementToken());
     assertEquals("ref2", tokenizer.getAttribute(CharTermAttribute.class).toString());
-    assertEquals(JsonReferencePayloadTokenizer.TYPE_NORMALIZED, tokenizer.getAttribute(TypeAttribute.class).type());
+    assertEquals(JsonReferencePayloadTokenizer.TYPE_FILING, tokenizer.getAttribute(TypeAttribute.class).type());
     assertEquals(3, tokenizer.getAttribute(PositionIncrementAttribute.class).getPositionIncrement());
-    assertEquals("use_for" + JsonReferencePayloadTokenizer.PAYLOAD_ATTR_SEPARATOR + "some value" + MultiPartString.DELIMITER + "some value", tokenizer.getAttribute(PayloadAttribute.class).getPayload().utf8ToString());
-
-    assertTrue(tokenizer.incrementToken());
-    assertEquals("ref2", tokenizer.getAttribute(CharTermAttribute.class).toString());
-    assertEquals(JsonReferencePayloadTokenizer.TYPE_FILING, tokenizer.getAttribute(TypeAttribute.class).type());
-    assertEquals(0, tokenizer.getAttribute(PositionIncrementAttribute.class).getPositionIncrement());
-    assertEquals("use_for" + JsonReferencePayloadTokenizer.PAYLOAD_ATTR_SEPARATOR + "some value" + MultiPartString.DELIMITER + "some value", tokenizer.getAttribute(PayloadAttribute.class).getPayload().utf8ToString());
+    assertEquals("use_for" + JsonReferencePayloadTokenizer.PAYLOAD_ATTR_SEPARATOR + "some value", tokenizer.getAttribute(PayloadAttribute.class).getPayload().utf8ToString());
 
     assertTrue(tokenizer.incrementToken());
     assertEquals("ref3", tokenizer.getAttribute(CharTermAttribute.class).toString());
-    assertEquals(JsonReferencePayloadTokenizer.TYPE_NORMALIZED, tokenizer.getAttribute(TypeAttribute.class).type());
+    assertEquals(JsonReferencePayloadTokenizer.TYPE_FILING, tokenizer.getAttribute(TypeAttribute.class).type());
     assertEquals(4, tokenizer.getAttribute(PositionIncrementAttribute.class).getPositionIncrement());
-    assertEquals("see_also" + JsonReferencePayloadTokenizer.PAYLOAD_ATTR_SEPARATOR + "some value" + MultiPartString.DELIMITER + "some value", tokenizer.getAttribute(PayloadAttribute.class).getPayload().utf8ToString());
-
-    assertTrue(tokenizer.incrementToken());
-    assertEquals("ref3", tokenizer.getAttribute(CharTermAttribute.class).toString());
-    assertEquals(JsonReferencePayloadTokenizer.TYPE_FILING, tokenizer.getAttribute(TypeAttribute.class).type());
-    assertEquals(0, tokenizer.getAttribute(PositionIncrementAttribute.class).getPositionIncrement());
-    assertEquals("see_also" + JsonReferencePayloadTokenizer.PAYLOAD_ATTR_SEPARATOR + "some value" + MultiPartString.DELIMITER + "some value", tokenizer.getAttribute(PayloadAttribute.class).getPayload().utf8ToString());
+    assertEquals("see_also" + JsonReferencePayloadTokenizer.PAYLOAD_ATTR_SEPARATOR + "some value", tokenizer.getAttribute(PayloadAttribute.class).getPayload().utf8ToString());
 
     assertFalse(tokenizer.incrementToken());
   }
@@ -79,14 +55,8 @@ public class JsonReferencePayloadTokenizerTest {
 
     assertTrue(tokenizer.incrementToken());
     assertEquals("unconsoled", tokenizer.getAttribute(CharTermAttribute.class).toString());
-    assertEquals(JsonReferencePayloadTokenizer.TYPE_NORMALIZED, tokenizer.getAttribute(TypeAttribute.class).type());
-    assertEquals(1, tokenizer.getAttribute(PositionIncrementAttribute.class).getPositionIncrement());
-    assertNull(tokenizer.getAttribute(PayloadAttribute.class).getPayload());
-
-    assertTrue(tokenizer.incrementToken());
-    assertEquals("unconsoled", tokenizer.getAttribute(CharTermAttribute.class).toString());
     assertEquals(JsonReferencePayloadTokenizer.TYPE_FILING, tokenizer.getAttribute(TypeAttribute.class).type());
-    assertEquals(0, tokenizer.getAttribute(PositionIncrementAttribute.class).getPositionIncrement());
+    assertEquals(1, tokenizer.getAttribute(PositionIncrementAttribute.class).getPositionIncrement());
     assertNull(tokenizer.getAttribute(PayloadAttribute.class).getPayload());
 
     assertTrue(tokenizer.incrementToken());
@@ -97,45 +67,27 @@ public class JsonReferencePayloadTokenizerTest {
 
     assertTrue(tokenizer.incrementToken());
     assertEquals("ref1", tokenizer.getAttribute(CharTermAttribute.class).toString());
-    assertEquals(JsonReferencePayloadTokenizer.TYPE_NORMALIZED, tokenizer.getAttribute(TypeAttribute.class).type());
+    assertEquals(JsonReferencePayloadTokenizer.TYPE_FILING, tokenizer.getAttribute(TypeAttribute.class).type());
     assertEquals(2, tokenizer.getAttribute(PositionIncrementAttribute.class).getPositionIncrement());
-    assertEquals("use_for" + JsonReferencePayloadTokenizer.PAYLOAD_ATTR_SEPARATOR + "unconsoled" + MultiPartString.DELIMITER + "unconsoled" + MultiPartString.DELIMITER + "the ", tokenizer.getAttribute(PayloadAttribute.class).getPayload().utf8ToString());
-
-    assertTrue(tokenizer.incrementToken());
-    assertEquals("ref1", tokenizer.getAttribute(CharTermAttribute.class).toString());
-    assertEquals(JsonReferencePayloadTokenizer.TYPE_FILING, tokenizer.getAttribute(TypeAttribute.class).type());
-    assertEquals(0, tokenizer.getAttribute(PositionIncrementAttribute.class).getPositionIncrement());
-    assertEquals("use_for" + JsonReferencePayloadTokenizer.PAYLOAD_ATTR_SEPARATOR + "unconsoled" + MultiPartString.DELIMITER + "unconsoled" + MultiPartString.DELIMITER + "the ", tokenizer.getAttribute(PayloadAttribute.class).getPayload().utf8ToString());
+    assertEquals("use_for" + JsonReferencePayloadTokenizer.PAYLOAD_ATTR_SEPARATOR + "unconsoled" + MultiPartString.DELIMITER + "the ", tokenizer.getAttribute(PayloadAttribute.class).getPayload().utf8ToString());
 
     assertTrue(tokenizer.incrementToken());
     assertEquals("chicken", tokenizer.getAttribute(CharTermAttribute.class).toString());
-    assertEquals(JsonReferencePayloadTokenizer.TYPE_NORMALIZED, tokenizer.getAttribute(TypeAttribute.class).type());
+    assertEquals(JsonReferencePayloadTokenizer.TYPE_FILING, tokenizer.getAttribute(TypeAttribute.class).type());
     assertEquals(3, tokenizer.getAttribute(PositionIncrementAttribute.class).getPositionIncrement());
-    assertEquals("use_for" + JsonReferencePayloadTokenizer.PAYLOAD_ATTR_SEPARATOR + "unconsoled" + MultiPartString.DELIMITER + "unconsoled" + MultiPartString.DELIMITER + "the ", tokenizer.getAttribute(PayloadAttribute.class).getPayload().utf8ToString());
-
-    assertTrue(tokenizer.incrementToken());
-    assertEquals("chicken", tokenizer.getAttribute(CharTermAttribute.class).toString());
-    assertEquals(JsonReferencePayloadTokenizer.TYPE_FILING, tokenizer.getAttribute(TypeAttribute.class).type());
-    assertEquals(0, tokenizer.getAttribute(PositionIncrementAttribute.class).getPositionIncrement());
-    assertEquals("use_for" + JsonReferencePayloadTokenizer.PAYLOAD_ATTR_SEPARATOR + "unconsoled" + MultiPartString.DELIMITER + "unconsoled" + MultiPartString.DELIMITER + "the ", tokenizer.getAttribute(PayloadAttribute.class).getPayload().utf8ToString());
+    assertEquals("use_for" + JsonReferencePayloadTokenizer.PAYLOAD_ATTR_SEPARATOR + "unconsoled" + MultiPartString.DELIMITER + "the ", tokenizer.getAttribute(PayloadAttribute.class).getPayload().utf8ToString());
 
     assertTrue(tokenizer.incrementToken());
     assertEquals("a ", tokenizer.getAttribute(CharTermAttribute.class).toString());
     assertEquals(JsonReferencePayloadTokenizer.TYPE_PREFIX, tokenizer.getAttribute(TypeAttribute.class).type());
     assertEquals(0, tokenizer.getAttribute(PositionIncrementAttribute.class).getPositionIncrement());
-    assertEquals("use_for" + JsonReferencePayloadTokenizer.PAYLOAD_ATTR_SEPARATOR + "unconsoled" + MultiPartString.DELIMITER + "unconsoled" + MultiPartString.DELIMITER + "the ", tokenizer.getAttribute(PayloadAttribute.class).getPayload().utf8ToString());
-
-    assertTrue(tokenizer.incrementToken());
-    assertEquals("ref3", tokenizer.getAttribute(CharTermAttribute.class).toString());
-    assertEquals(JsonReferencePayloadTokenizer.TYPE_NORMALIZED, tokenizer.getAttribute(TypeAttribute.class).type());
-    assertEquals(4, tokenizer.getAttribute(PositionIncrementAttribute.class).getPositionIncrement());
-    assertEquals("see_also" + JsonReferencePayloadTokenizer.PAYLOAD_ATTR_SEPARATOR + "unconsoled" + MultiPartString.DELIMITER + "unconsoled" + MultiPartString.DELIMITER + "the ", tokenizer.getAttribute(PayloadAttribute.class).getPayload().utf8ToString());
+    assertEquals("use_for" + JsonReferencePayloadTokenizer.PAYLOAD_ATTR_SEPARATOR + "unconsoled" + MultiPartString.DELIMITER + "the ", tokenizer.getAttribute(PayloadAttribute.class).getPayload().utf8ToString());
 
     assertTrue(tokenizer.incrementToken());
     assertEquals("ref3", tokenizer.getAttribute(CharTermAttribute.class).toString());
     assertEquals(JsonReferencePayloadTokenizer.TYPE_FILING, tokenizer.getAttribute(TypeAttribute.class).type());
-    assertEquals(0, tokenizer.getAttribute(PositionIncrementAttribute.class).getPositionIncrement());
-    assertEquals("see_also" + JsonReferencePayloadTokenizer.PAYLOAD_ATTR_SEPARATOR + "unconsoled" + MultiPartString.DELIMITER + "unconsoled" + MultiPartString.DELIMITER + "the ", tokenizer.getAttribute(PayloadAttribute.class).getPayload().utf8ToString());
+    assertEquals(4, tokenizer.getAttribute(PositionIncrementAttribute.class).getPositionIncrement());
+    assertEquals("see_also" + JsonReferencePayloadTokenizer.PAYLOAD_ATTR_SEPARATOR + "unconsoled" + MultiPartString.DELIMITER + "the ", tokenizer.getAttribute(PayloadAttribute.class).getPayload().utf8ToString());
 
     assertFalse(tokenizer.incrementToken());
   }

--- a/src/test/java/edu/upenn/library/solrplugins/JsonReferencePayloadTokenizerTest.java
+++ b/src/test/java/edu/upenn/library/solrplugins/JsonReferencePayloadTokenizerTest.java
@@ -5,7 +5,10 @@ import java.io.StringReader;
 import static junit.framework.Assert.assertEquals;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
 import org.apache.lucene.analysis.tokenattributes.PayloadAttribute;
+import org.apache.lucene.analysis.tokenattributes.PositionIncrementAttribute;
+import org.apache.lucene.analysis.tokenattributes.TypeAttribute;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 
@@ -19,18 +22,120 @@ public class JsonReferencePayloadTokenizerTest {
 
     assertTrue(tokenizer.incrementToken());
     assertEquals("some value", tokenizer.getAttribute(CharTermAttribute.class).toString());
+    assertEquals(JsonReferencePayloadTokenizer.TYPE_NORMALIZED, tokenizer.getAttribute(TypeAttribute.class).type());
+    assertEquals(1, tokenizer.getAttribute(PositionIncrementAttribute.class).getPositionIncrement());
+    assertNull(tokenizer.getAttribute(PayloadAttribute.class).getPayload());
+
+    assertTrue(tokenizer.incrementToken());
+    assertEquals("some value", tokenizer.getAttribute(CharTermAttribute.class).toString());
+    assertEquals(JsonReferencePayloadTokenizer.TYPE_FILING, tokenizer.getAttribute(TypeAttribute.class).type());
+    assertEquals(0, tokenizer.getAttribute(PositionIncrementAttribute.class).getPositionIncrement());
+    assertNull(tokenizer.getAttribute(PayloadAttribute.class).getPayload());
 
     assertTrue(tokenizer.incrementToken());
     assertEquals("ref1", tokenizer.getAttribute(CharTermAttribute.class).toString());
+    assertEquals(JsonReferencePayloadTokenizer.TYPE_NORMALIZED, tokenizer.getAttribute(TypeAttribute.class).type());
+    assertEquals(2, tokenizer.getAttribute(PositionIncrementAttribute.class).getPositionIncrement());
+    assertEquals("use_for" + JsonReferencePayloadTokenizer.PAYLOAD_ATTR_SEPARATOR + "some value", tokenizer.getAttribute(PayloadAttribute.class).getPayload().utf8ToString());
+
+    assertTrue(tokenizer.incrementToken());
+    assertEquals("ref1", tokenizer.getAttribute(CharTermAttribute.class).toString());
+    assertEquals(JsonReferencePayloadTokenizer.TYPE_FILING, tokenizer.getAttribute(TypeAttribute.class).type());
+    assertEquals(0, tokenizer.getAttribute(PositionIncrementAttribute.class).getPositionIncrement());
     assertEquals("use_for" + JsonReferencePayloadTokenizer.PAYLOAD_ATTR_SEPARATOR + "some value", tokenizer.getAttribute(PayloadAttribute.class).getPayload().utf8ToString());
 
     assertTrue(tokenizer.incrementToken());
     assertEquals("ref2", tokenizer.getAttribute(CharTermAttribute.class).toString());
+    assertEquals(JsonReferencePayloadTokenizer.TYPE_NORMALIZED, tokenizer.getAttribute(TypeAttribute.class).type());
+    assertEquals(3, tokenizer.getAttribute(PositionIncrementAttribute.class).getPositionIncrement());
+    assertEquals("use_for" + JsonReferencePayloadTokenizer.PAYLOAD_ATTR_SEPARATOR + "some value", tokenizer.getAttribute(PayloadAttribute.class).getPayload().utf8ToString());
+
+    assertTrue(tokenizer.incrementToken());
+    assertEquals("ref2", tokenizer.getAttribute(CharTermAttribute.class).toString());
+    assertEquals(JsonReferencePayloadTokenizer.TYPE_FILING, tokenizer.getAttribute(TypeAttribute.class).type());
+    assertEquals(0, tokenizer.getAttribute(PositionIncrementAttribute.class).getPositionIncrement());
     assertEquals("use_for" + JsonReferencePayloadTokenizer.PAYLOAD_ATTR_SEPARATOR + "some value", tokenizer.getAttribute(PayloadAttribute.class).getPayload().utf8ToString());
 
     assertTrue(tokenizer.incrementToken());
     assertEquals("ref3", tokenizer.getAttribute(CharTermAttribute.class).toString());
+    assertEquals(JsonReferencePayloadTokenizer.TYPE_NORMALIZED, tokenizer.getAttribute(TypeAttribute.class).type());
+    assertEquals(4, tokenizer.getAttribute(PositionIncrementAttribute.class).getPositionIncrement());
     assertEquals("see_also" + JsonReferencePayloadTokenizer.PAYLOAD_ATTR_SEPARATOR + "some value", tokenizer.getAttribute(PayloadAttribute.class).getPayload().utf8ToString());
+
+    assertTrue(tokenizer.incrementToken());
+    assertEquals("ref3", tokenizer.getAttribute(CharTermAttribute.class).toString());
+    assertEquals(JsonReferencePayloadTokenizer.TYPE_FILING, tokenizer.getAttribute(TypeAttribute.class).type());
+    assertEquals(0, tokenizer.getAttribute(PositionIncrementAttribute.class).getPositionIncrement());
+    assertEquals("see_also" + JsonReferencePayloadTokenizer.PAYLOAD_ATTR_SEPARATOR + "some value", tokenizer.getAttribute(PayloadAttribute.class).getPayload().utf8ToString());
+
+    assertFalse(tokenizer.incrementToken());
+  }
+
+  @Test
+  public void testMultipartStrings() throws IOException {
+    JsonReferencePayloadTokenizer tokenizer = new JsonReferencePayloadTokenizer();
+    tokenizer.setReader(new StringReader("{\"raw\": {\"prefix\": \"the \", \"filing\": \"unconsoled\"}, \"refs\": {\"use_for\":[\"ref1\",{\"prefix\": \"a \", \"filing\": \"chicken\"}], \"see_also\":[\"ref3\"]}}"));
+    tokenizer.reset();
+
+    assertTrue(tokenizer.incrementToken());
+    assertEquals("unconsoled", tokenizer.getAttribute(CharTermAttribute.class).toString());
+    assertEquals(JsonReferencePayloadTokenizer.TYPE_NORMALIZED, tokenizer.getAttribute(TypeAttribute.class).type());
+    assertEquals(1, tokenizer.getAttribute(PositionIncrementAttribute.class).getPositionIncrement());
+    assertNull(tokenizer.getAttribute(PayloadAttribute.class).getPayload());
+
+    assertTrue(tokenizer.incrementToken());
+    assertEquals("unconsoled", tokenizer.getAttribute(CharTermAttribute.class).toString());
+    assertEquals(JsonReferencePayloadTokenizer.TYPE_FILING, tokenizer.getAttribute(TypeAttribute.class).type());
+    assertEquals(0, tokenizer.getAttribute(PositionIncrementAttribute.class).getPositionIncrement());
+    assertNull(tokenizer.getAttribute(PayloadAttribute.class).getPayload());
+
+    assertTrue(tokenizer.incrementToken());
+    assertEquals("the ", tokenizer.getAttribute(CharTermAttribute.class).toString());
+    assertEquals(JsonReferencePayloadTokenizer.TYPE_PREFIX, tokenizer.getAttribute(TypeAttribute.class).type());
+    assertEquals(0, tokenizer.getAttribute(PositionIncrementAttribute.class).getPositionIncrement());
+    assertNull(tokenizer.getAttribute(PayloadAttribute.class).getPayload());
+
+    assertTrue(tokenizer.incrementToken());
+    assertEquals("ref1", tokenizer.getAttribute(CharTermAttribute.class).toString());
+    assertEquals(JsonReferencePayloadTokenizer.TYPE_NORMALIZED, tokenizer.getAttribute(TypeAttribute.class).type());
+    assertEquals(2, tokenizer.getAttribute(PositionIncrementAttribute.class).getPositionIncrement());
+    assertEquals("use_for" + JsonReferencePayloadTokenizer.PAYLOAD_ATTR_SEPARATOR + "the unconsoled", tokenizer.getAttribute(PayloadAttribute.class).getPayload().utf8ToString());
+
+    assertTrue(tokenizer.incrementToken());
+    assertEquals("ref1", tokenizer.getAttribute(CharTermAttribute.class).toString());
+    assertEquals(JsonReferencePayloadTokenizer.TYPE_FILING, tokenizer.getAttribute(TypeAttribute.class).type());
+    assertEquals(0, tokenizer.getAttribute(PositionIncrementAttribute.class).getPositionIncrement());
+    assertEquals("use_for" + JsonReferencePayloadTokenizer.PAYLOAD_ATTR_SEPARATOR + "the unconsoled", tokenizer.getAttribute(PayloadAttribute.class).getPayload().utf8ToString());
+
+    assertTrue(tokenizer.incrementToken());
+    assertEquals("chicken", tokenizer.getAttribute(CharTermAttribute.class).toString());
+    assertEquals(JsonReferencePayloadTokenizer.TYPE_NORMALIZED, tokenizer.getAttribute(TypeAttribute.class).type());
+    assertEquals(3, tokenizer.getAttribute(PositionIncrementAttribute.class).getPositionIncrement());
+    assertEquals("use_for" + JsonReferencePayloadTokenizer.PAYLOAD_ATTR_SEPARATOR + "the unconsoled", tokenizer.getAttribute(PayloadAttribute.class).getPayload().utf8ToString());
+
+    assertTrue(tokenizer.incrementToken());
+    assertEquals("chicken", tokenizer.getAttribute(CharTermAttribute.class).toString());
+    assertEquals(JsonReferencePayloadTokenizer.TYPE_FILING, tokenizer.getAttribute(TypeAttribute.class).type());
+    assertEquals(0, tokenizer.getAttribute(PositionIncrementAttribute.class).getPositionIncrement());
+    assertEquals("use_for" + JsonReferencePayloadTokenizer.PAYLOAD_ATTR_SEPARATOR + "the unconsoled", tokenizer.getAttribute(PayloadAttribute.class).getPayload().utf8ToString());
+
+    assertTrue(tokenizer.incrementToken());
+    assertEquals("a ", tokenizer.getAttribute(CharTermAttribute.class).toString());
+    assertEquals(JsonReferencePayloadTokenizer.TYPE_PREFIX, tokenizer.getAttribute(TypeAttribute.class).type());
+    assertEquals(0, tokenizer.getAttribute(PositionIncrementAttribute.class).getPositionIncrement());
+    assertEquals("use_for" + JsonReferencePayloadTokenizer.PAYLOAD_ATTR_SEPARATOR + "the unconsoled", tokenizer.getAttribute(PayloadAttribute.class).getPayload().utf8ToString());
+
+    assertTrue(tokenizer.incrementToken());
+    assertEquals("ref3", tokenizer.getAttribute(CharTermAttribute.class).toString());
+    assertEquals(JsonReferencePayloadTokenizer.TYPE_NORMALIZED, tokenizer.getAttribute(TypeAttribute.class).type());
+    assertEquals(4, tokenizer.getAttribute(PositionIncrementAttribute.class).getPositionIncrement());
+    assertEquals("see_also" + JsonReferencePayloadTokenizer.PAYLOAD_ATTR_SEPARATOR + "the unconsoled", tokenizer.getAttribute(PayloadAttribute.class).getPayload().utf8ToString());
+
+    assertTrue(tokenizer.incrementToken());
+    assertEquals("ref3", tokenizer.getAttribute(CharTermAttribute.class).toString());
+    assertEquals(JsonReferencePayloadTokenizer.TYPE_FILING, tokenizer.getAttribute(TypeAttribute.class).type());
+    assertEquals(0, tokenizer.getAttribute(PositionIncrementAttribute.class).getPositionIncrement());
+    assertEquals("see_also" + JsonReferencePayloadTokenizer.PAYLOAD_ATTR_SEPARATOR + "the unconsoled", tokenizer.getAttribute(PayloadAttribute.class).getPayload().utf8ToString());
 
     assertFalse(tokenizer.incrementToken());
   }

--- a/src/test/java/edu/upenn/library/solrplugins/tokentype/TokenTypeJoinFilterTest.java
+++ b/src/test/java/edu/upenn/library/solrplugins/tokentype/TokenTypeJoinFilterTest.java
@@ -17,6 +17,7 @@
 package edu.upenn.library.solrplugins.tokentype;
 
 import org.apache.lucene.analysis.BaseTokenStreamTestCase;
+import org.apache.lucene.analysis.Tokenizer;
 import org.apache.lucene.analysis.tokenattributes.OffsetAttribute;
 
 import java.io.IOException;
@@ -25,8 +26,10 @@ import static junit.framework.Assert.assertTrue;
 import org.apache.lucene.analysis.TokenFilter;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
+import org.apache.lucene.analysis.tokenattributes.PayloadAttribute;
 import org.apache.lucene.analysis.tokenattributes.PositionIncrementAttribute;
 import org.apache.lucene.analysis.tokenattributes.TypeAttribute;
+import org.apache.lucene.util.BytesRef;
 
 public class TokenTypeJoinFilterTest extends BaseTokenStreamTestCase {
 
@@ -38,12 +41,13 @@ public class TokenTypeJoinFilterTest extends BaseTokenStreamTestCase {
         Collections.EMPTY_SET, "even_fork", "even_orig");
     TokenTypeSplitFilter ttsfOdd = new TokenTypeSplitFilter(ttsf, Collections.singleton("odd"),
         Collections.EMPTY_SET, "odd_fork", "odd_orig");
-    TokenTypeJoinFilter ttjf = new TokenTypeJoinFilter(ttsfOdd, new String[] {"even_orig", "even_fork"}, "joined", "!", false, true);
+    TokenTypeJoinFilter ttjf = new TokenTypeJoinFilter(ttsfOdd, new String[] {"even_orig", "even_fork"}, "joined", null, "!", false, true);
     int count = 0;
     TypeAttribute typeAtt = ttjf.getAttribute(TypeAttribute.class);
     OffsetAttribute offsetAtt = ttjf.getAttribute(OffsetAttribute.class);
     PositionIncrementAttribute posIncrAtt = ttjf.getAttribute(PositionIncrementAttribute.class);
     CharTermAttribute termAtt = ttjf.getAttribute(CharTermAttribute.class);
+    PayloadAttribute payloadAtt = ttjf.getAttribute(PayloadAttribute.class);
     String lastTerm = null;
     int lastStartOffset = -1;
     int lastEndOffset = -1;
@@ -54,6 +58,7 @@ public class TokenTypeJoinFilterTest extends BaseTokenStreamTestCase {
       int startOffset = offsetAtt.startOffset();
       int endOffset = offsetAtt.endOffset();
       int posIncr = posIncrAtt.getPositionIncrement();
+      BytesRef payload = payloadAtt.getPayload();
       switch (count % 3) {
         case 0:
           assertEquals("joined", type);
@@ -61,11 +66,13 @@ public class TokenTypeJoinFilterTest extends BaseTokenStreamTestCase {
           assertEquals(lastEndOffset + 1, startOffset);
           String[] split = term.split("!");
           assertEquals(split[0], split[1]);
+          assertNull(payload);
           break;
         case 1:
           assertEquals("odd_orig", type);
           assertEquals(1, posIncr);
           assertEquals(lastEndOffset + 1, startOffset);
+          assertNull(payload);
           break;
         case 2:
           assertEquals("odd_fork", type);
@@ -73,6 +80,7 @@ public class TokenTypeJoinFilterTest extends BaseTokenStreamTestCase {
           assertEquals(0, posIncr);
           assertEquals(lastStartOffset, startOffset);
           assertEquals(lastEndOffset, endOffset);
+          assertNull(payload);
           break;
       }
       lastTerm = term;
@@ -91,12 +99,13 @@ public class TokenTypeJoinFilterTest extends BaseTokenStreamTestCase {
         Collections.EMPTY_SET, "even_fork", "even_orig");
     TokenTypeSplitFilter ttsfOdd = new TokenTypeSplitFilter(ttsf, Collections.singleton("odd"),
         Collections.EMPTY_SET, "odd_fork", "odd_orig");
-    TokenTypeJoinFilter ttjf = new TokenTypeJoinFilter(ttsfOdd, new String[] {"even_orig", "even_fork"}, "joined", "!", true, true);
+    TokenTypeJoinFilter ttjf = new TokenTypeJoinFilter(ttsfOdd, new String[] {"even_orig", "even_fork"}, "joined", null, "!", true, true);
     int count = 0;
     TypeAttribute typeAtt = ttjf.getAttribute(TypeAttribute.class);
     OffsetAttribute offsetAtt = ttjf.getAttribute(OffsetAttribute.class);
     PositionIncrementAttribute posIncrAtt = ttjf.getAttribute(PositionIncrementAttribute.class);
     CharTermAttribute termAtt = ttjf.getAttribute(CharTermAttribute.class);
+    PayloadAttribute payloadAtt = ttjf.getAttribute(PayloadAttribute.class);
     String lastTerm = null;
     int lastStartOffset = -1;
     int lastEndOffset = -1;
@@ -107,11 +116,13 @@ public class TokenTypeJoinFilterTest extends BaseTokenStreamTestCase {
       int startOffset = offsetAtt.startOffset();
       int endOffset = offsetAtt.endOffset();
       int posIncr = posIncrAtt.getPositionIncrement();
+      BytesRef payload = payloadAtt.getPayload();
       switch (count % 5) {
         case 0:
           assertEquals("even_orig", type);
           assertEquals(1, posIncr);
           assertEquals(lastEndOffset + 1, startOffset);
+          assertNull(payload);
           break;
         case 1:
           assertEquals("even_fork", type);
@@ -119,6 +130,7 @@ public class TokenTypeJoinFilterTest extends BaseTokenStreamTestCase {
           assertEquals(0, posIncr);
           assertEquals(lastStartOffset, startOffset);
           assertEquals(lastEndOffset, endOffset);
+          assertNull(payload);
           break;
         case 2:
           assertEquals("joined", type);
@@ -126,11 +138,13 @@ public class TokenTypeJoinFilterTest extends BaseTokenStreamTestCase {
           assertEquals(lastStartOffset, startOffset);
           String[] split = term.split("!");
           assertEquals(split[0], split[1]);
+          assertNull(payload);
           break;
         case 3:
           assertEquals("odd_orig", type);
           assertEquals(1, posIncr);
           assertEquals(lastEndOffset + 1, startOffset);
+          assertNull(payload);
           break;
         case 4:
           assertEquals("odd_fork", type);
@@ -138,6 +152,7 @@ public class TokenTypeJoinFilterTest extends BaseTokenStreamTestCase {
           assertEquals(0, posIncr);
           assertEquals(lastStartOffset, startOffset);
           assertEquals(lastEndOffset, endOffset);
+          assertNull(payload);
           break;
       }
       lastTerm = term;
@@ -152,31 +167,138 @@ public class TokenTypeJoinFilterTest extends BaseTokenStreamTestCase {
   public void testVariableTokenPresence() throws IOException {
     String test = "The Quick Red Fox Jumped Over The Lazy Brown Dogs";
     TokenTypeJoinFilter ttjf = new TokenTypeJoinFilter(new Blah2(whitespaceMockTokenizer(test)), new String[] {"raw", "lower", "upper"}, 
-        "joined", "!", false, false);
+        "joined", null, "!", false, false);
     CharTermAttribute termAtt = ttjf.getAttribute(CharTermAttribute.class);
+    PayloadAttribute payloadAtt = ttjf.getAttribute(PayloadAttribute.class);
     ttjf.reset();
     int i = -1;
     String[] split = test.split(" ");
     StringBuilder sb = new StringBuilder();
     while (ttjf.incrementToken()) {
       String term = termAtt.toString();
+      BytesRef payload = payloadAtt.getPayload();
       switch (++i) {
         case 0:
           assertEquals(split[i], term);
+          assertNull(payload);
           break;
         case 1:
           sb.setLength(0);
           sb.append(split[i]).append('!').append(split[i].toUpperCase());
           assertEquals(sb.toString(), term);
+          assertNull(payload);
           break;
         case 2:
           sb.setLength(0);
           sb.append(split[i]).append('!').append(split[i].toLowerCase()).append('!').append(split[i].toUpperCase());
           assertEquals(sb.toString(), term);
+          assertNull(payload);
           break;
       }
     }
   }
+
+  TokenArrayTokenizer.Token[] tokensWithPayloads = new TokenArrayTokenizer.Token[] {
+          new TokenArrayTokenizer.Token("unconsoled", "normalized", 1, "payload1"),
+          new TokenArrayTokenizer.Token("Unconsoled", "filing", 0, null),
+          new TokenArrayTokenizer.Token("The ", "prefix", 0, null),
+
+          new TokenArrayTokenizer.Token("room with a view", "normalized", 2, null),
+          new TokenArrayTokenizer.Token("Room With A View", "filing", 0, "payload2"),
+          new TokenArrayTokenizer.Token("A ", "prefix", 0, null),
+  };
+
+  /** verify that payload gets picked up for 1st group of tokens */
+  public void testTypeForPayload1() throws IOException {
+    TokenTypeJoinFilter ttjf = new TokenTypeJoinFilter(new TokenArrayTokenizer(tokensWithPayloads), new String[] {"normalized", "filing", "prefix"},
+            "joined", "normalized", "!", false, false);
+    CharTermAttribute termAtt = ttjf.getAttribute(CharTermAttribute.class);
+    TypeAttribute typeAtt = ttjf.getAttribute(TypeAttribute.class);
+    PayloadAttribute payloadAtt = ttjf.getAttribute(PayloadAttribute.class);
+    ttjf.reset();
+
+    assertTrue(ttjf.incrementToken());
+
+    assertEquals("unconsoled!Unconsoled!The ", termAtt.toString());
+    assertEquals("joined", typeAtt.type());
+    assertEquals("payload1", payloadAtt.getPayload().utf8ToString());
+
+    assertTrue(ttjf.incrementToken());
+
+    assertEquals("room with a view!Room With A View!A ", termAtt.toString());
+    assertEquals("joined", typeAtt.type());
+    assertNull(payloadAtt.getPayload());
+
+    assertFalse(ttjf.incrementToken());
+  }
+
+  /** verify that payload gets picked up for 2nd group of tokens */
+  public void testTypeForPayload2() throws IOException {
+    TokenTypeJoinFilter ttjf = new TokenTypeJoinFilter(new TokenArrayTokenizer(tokensWithPayloads), new String[] {"normalized", "filing", "prefix"},
+            "joined", "filing", "!", false, false);
+    CharTermAttribute termAtt = ttjf.getAttribute(CharTermAttribute.class);
+    TypeAttribute typeAtt = ttjf.getAttribute(TypeAttribute.class);
+    PayloadAttribute payloadAtt = ttjf.getAttribute(PayloadAttribute.class);
+    ttjf.reset();
+
+    assertTrue(ttjf.incrementToken());
+
+    assertEquals("unconsoled!Unconsoled!The ", termAtt.toString());
+    assertEquals("joined", typeAtt.type());
+    assertNull(payloadAtt.getPayload());
+
+    assertTrue(ttjf.incrementToken());
+
+    assertEquals("room with a view!Room With A View!A ", termAtt.toString());
+    assertEquals("joined", typeAtt.type());
+    assertEquals("payload2", payloadAtt.getPayload().utf8ToString());
+
+    assertFalse(ttjf.incrementToken());
+  }
+
+  /** verify that payload gets overwritten properly across groups of tokens*/
+  public void testTypeForPayload3() throws IOException {
+    TokenArrayTokenizer.Token[] tokensWithPayloads = new TokenArrayTokenizer.Token[] {
+            new TokenArrayTokenizer.Token("unconsoled", "normalized", 1, null),
+            new TokenArrayTokenizer.Token("Unconsoled", "filing", 0, "payload1"),
+            new TokenArrayTokenizer.Token("The ", "prefix", 0, null),
+
+            new TokenArrayTokenizer.Token("room with a view", "normalized", 2, null),
+            new TokenArrayTokenizer.Token("Room With A View", "filing", 0, "payload2"),
+            new TokenArrayTokenizer.Token("A ", "prefix", 0, null),
+
+            new TokenArrayTokenizer.Token("no payload", "normalized", 3, null),
+            new TokenArrayTokenizer.Token("No Payload", "filing", 0, null),
+    };
+
+    TokenTypeJoinFilter ttjf = new TokenTypeJoinFilter(new TokenArrayTokenizer(tokensWithPayloads), new String[] {"normalized", "filing", "prefix"},
+            "joined", "filing", "!", false, false);
+    CharTermAttribute termAtt = ttjf.getAttribute(CharTermAttribute.class);
+    TypeAttribute typeAtt = ttjf.getAttribute(TypeAttribute.class);
+    PayloadAttribute payloadAtt = ttjf.getAttribute(PayloadAttribute.class);
+    ttjf.reset();
+
+    assertTrue(ttjf.incrementToken());
+
+    assertEquals("unconsoled!Unconsoled!The ", termAtt.toString());
+    assertEquals("joined", typeAtt.type());
+    assertEquals("payload1", payloadAtt.getPayload().utf8ToString());
+
+    assertTrue(ttjf.incrementToken());
+
+    assertEquals("room with a view!Room With A View!A ", termAtt.toString());
+    assertEquals("joined", typeAtt.type());
+    assertEquals("payload2", payloadAtt.getPayload().utf8ToString());
+
+    assertTrue(ttjf.incrementToken());
+
+    assertEquals("no payload!No Payload", termAtt.toString());
+    assertEquals("joined", typeAtt.type());
+    assertNull(payloadAtt.getPayload());
+
+    assertFalse(ttjf.incrementToken());
+  }
+
 
   private static final class Blah extends TokenFilter {
 
@@ -256,5 +378,48 @@ public class TokenTypeJoinFilterTest extends BaseTokenStreamTestCase {
 
   }
 
+  /** Tokenizer that simply emits the tokens passed into the constructor */
+  public static final class TokenArrayTokenizer extends Tokenizer {
+    private final TypeAttribute typeAtt = addAttribute(TypeAttribute.class);
+    private final CharTermAttribute termAtt = addAttribute(CharTermAttribute.class);
+    private final PositionIncrementAttribute posIncrAtt = addAttribute(PositionIncrementAttribute.class);
+    private final PayloadAttribute payloadAtt = addAttribute(PayloadAttribute.class);
+    private int i = 0;
+    private Token[] tokens;
+
+    public static class Token {
+      String term;
+      String type;
+      int positionIncrement;
+      String payload;
+      public Token(String term, String type, int positionIncrement, String payload) {
+        this.term = term;
+        this.type = type;
+        this.positionIncrement = positionIncrement;
+        this.payload = payload;
+      }
+    }
+
+    public TokenArrayTokenizer(Token[] tokens) {
+      this.tokens = tokens;
+    }
+
+    @Override
+    public boolean incrementToken() throws IOException {
+      clearAttributes();
+      if(i < tokens.length) {
+        Token t = tokens[i];
+        i++;
+        typeAtt.setType(t.type);
+        termAtt.append(t.term);
+        posIncrAtt.setPositionIncrement(t.positionIncrement);
+        if(t.payload != null) {
+          payloadAtt.setPayload(new BytesRef(t.payload));
+        }
+        return true;
+      }
+      return false;
+    }
+  }
 
 }


### PR DESCRIPTION
JsonReferencePayloadTokenizer now emits normalized, filing and prefix token types, and these are included in facets
