### PR TITLE
fill out reset() so all state is really reset

### DIFF
--- a/src/main/java/edu/upenn/library/solrplugins/tokentype/TokenTypeJoinFilter.java
+++ b/src/main/java/edu/upenn/library/solrplugins/tokentype/TokenTypeJoinFilter.java
@@ -162,6 +162,10 @@ public final class TokenTypeJoinFilter extends TokenFilter {
   @Override
   public void reset() throws IOException {
     primed = false;
+    bufferedOffsetStart = 0;
+    bufferedOffsetEnd = 0;
+    payload = null;
+    exhausted = false;
     increment = 0;
     state = null;
     Arrays.fill(components, null);


### PR DESCRIPTION
This fixes a bug where stale state in the join filter makes it stop returning anything after a few uses.
