### PR TITLE
Doc centric facet results

### DIFF
--- a/src/main/java/edu/upenn/library/solrplugins/CaseInsensitiveSortingTextField.java
+++ b/src/main/java/edu/upenn/library/solrplugins/CaseInsensitiveSortingTextField.java
@@ -44,7 +44,8 @@ import org.apache.solr.schema.TextField;
 public class CaseInsensitiveSortingTextField extends TextField implements MultiSerializable, FacetPayload {
 
   private static final String NORMALIZED_TOKEN_TYPE = "normalized";
-  private static final String RAW_TOKEN_TYPE = "raw";
+  private static final String RAW_TOKEN_TYPE = "filing";
+  private static final String PREFIX_TOKEN_TYPE = "prefix";
   private static final String INDEXED_TOKEN_TYPE = "indexed";
 
   private static final String SERIALIZER_ARGNAME = "serializer";

--- a/src/main/java/edu/upenn/library/solrplugins/CaseInsensitiveSortingTextField.java
+++ b/src/main/java/edu/upenn/library/solrplugins/CaseInsensitiveSortingTextField.java
@@ -24,6 +24,7 @@ import java.util.Map.Entry;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
 import org.apache.lucene.analysis.tokenattributes.TypeAttribute;
+import org.apache.lucene.document.Document;
 import org.apache.lucene.index.PostingsEnum;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefBuilder;
@@ -49,6 +50,7 @@ public class CaseInsensitiveSortingTextField extends TextField implements MultiS
   private static final String SERIALIZER_ARGNAME = "serializer";
   private static final String DISPLAYIZER_ARGNAME = "displayizer";
   private static final String PAYLOAD_HANDLER_ARGNAME = "payloadHandler";
+  private static final String DOC_PAYLOAD_HANDLER_ARGNAME = "docPayloadHandler";
   private static final String HIERARCHY_LEVEL_ARGNAME = "hierarchyLevel";
   private static final char DELIM_CHAR = '\u0000';
   private static final int DEFAULT_HIERARCHY_LEVEL = 0;
@@ -239,30 +241,30 @@ public class CaseInsensitiveSortingTextField extends TextField implements MultiS
     return payloadHandler.updateValueExternalRepresentation(internal);
   }
 
-  private static class DefaultPayloadHandler implements FacetPayload<Void> {
+  private static class DefaultPayloadHandler implements FacetPayload<Object> {
 
     @Override
-    public boolean addEntry(String termKey, long count, PostingsEnum postings, NamedList<Void> res) throws IOException {
+    public boolean addEntry(String termKey, long count, PostingsEnum postings, NamedList<Object> res) throws IOException {
       return false;
     }
 
     @Override
-    public Entry<String, Void> addEntry(String termKey, long count, PostingsEnum postings) throws IOException {
+    public Entry<String, Object> addEntry(String termKey, long count, PostingsEnum postings) throws IOException {
       return null;
     }
 
     @Override
-    public Void mergePayload(Void preExisting, Void add, long preExistingCount, long addCount) {
+    public Object mergePayload(Object preExisting, Object add, long preExistingCount, long addCount) {
       return null;
     }
 
     @Override
-    public long extractCount(Void val) {
-      throw new UnsupportedOperationException("Not supported; misconfiguration; this should never happen.");
+    public long extractCount(Object val) {
+      return 1L; // for document-centric results only.
     }
 
     @Override
-    public Object updateValueExternalRepresentation(Void internal) {
+    public Object updateValueExternalRepresentation(Object internal) {
       return null;
     }
 

--- a/src/main/java/edu/upenn/library/solrplugins/CaseInsensitiveSortingTextField.java
+++ b/src/main/java/edu/upenn/library/solrplugins/CaseInsensitiveSortingTextField.java
@@ -50,7 +50,6 @@ public class CaseInsensitiveSortingTextField extends TextField implements MultiS
   private static final String SERIALIZER_ARGNAME = "serializer";
   private static final String DISPLAYIZER_ARGNAME = "displayizer";
   private static final String PAYLOAD_HANDLER_ARGNAME = "payloadHandler";
-  private static final String DOC_PAYLOAD_HANDLER_ARGNAME = "docPayloadHandler";
   private static final String HIERARCHY_LEVEL_ARGNAME = "hierarchyLevel";
   private static final char DELIM_CHAR = '\u0000';
   private static final int DEFAULT_HIERARCHY_LEVEL = 0;
@@ -91,8 +90,13 @@ public class CaseInsensitiveSortingTextField extends TextField implements MultiS
   }
 
   @Override
+  public String getDelim() {
+    return delim;
+  }
+
+  @Override
   public BytesRef normalizeQueryTarget(String val, boolean strict, String fieldName) throws IOException {
-    TokenStream ts = getQueryAnalyzer().tokenStream(fieldName, new StringReader(val));
+    TokenStream ts = getQueryAnalyzer().tokenStream(fieldName, val);
     try {
       ts.reset();
       CharTermAttribute termAtt = ts.getAttribute(CharTermAttribute.class);

--- a/src/main/java/edu/upenn/library/solrplugins/tokentype/TokenTypeJoinFilter.java
+++ b/src/main/java/edu/upenn/library/solrplugins/tokentype/TokenTypeJoinFilter.java
@@ -161,6 +161,7 @@ public final class TokenTypeJoinFilter extends TokenFilter {
 
   @Override
   public void reset() throws IOException {
+    exhausted = false;
     primed = false;
     increment = 0;
     state = null;

--- a/src/main/java/org/apache/solr/handler/component/FacetComponent.java
+++ b/src/main/java/org/apache/solr/handler/component/FacetComponent.java
@@ -34,6 +34,7 @@ import java.util.Map.Entry;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.lucene.util.FixedBitSet;
+import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.SolrException.ErrorCode;
 import org.apache.solr.common.params.CommonParams;
@@ -45,8 +46,7 @@ import org.apache.solr.common.util.NamedList;
 import org.apache.solr.common.util.SimpleOrderedMap;
 import org.apache.solr.common.util.StrUtils;
 import org.apache.solr.request.BidirectionalFacetResponseBuilder;
-import org.apache.solr.request.BidirectionalFacetResponseBuilder.AscendingFacetTermIteratorFactory;
-import org.apache.solr.request.BidirectionalFacetResponseBuilder.DescendingFacetTermIteratorFactory;
+import org.apache.solr.request.BidirectionalFacetResponseBuilder.DistribDocEnv;
 import org.apache.solr.request.BidirectionalFacetResponseBuilder.DistribEnv;
 import org.apache.solr.request.BidirectionalFacetResponseBuilder.Env;
 import org.apache.solr.request.FacetPayload;
@@ -1178,11 +1178,16 @@ public class FacetComponent extends SearchComponent {
       } else {
         // index order with target/offset
         int targetIdx = Arrays.binarySearch(counts, dff.target, (o1, o2) -> o1.indexed.compareTo(o2.indexed));
-        Env env = new DistribEnv(dff.offset, dff.limit, targetIdx,
+        Env env;
+        if (dff.targetDoc == null) {
+          env = new DistribEnv(dff.offset, dff.limit, targetIdx,
             dff.minCount, dff.field, dff.ftype, fieldCounts, counts);
+        } else {
+          env = new DistribDocEnv(dff.offset, dff.limit, targetIdx,
+            dff.minCount, dff.field, dff.ftype, fieldCounts, counts);
+        }
         try {
-          termVals = BidirectionalFacetResponseBuilder.build(env, new DescendingFacetTermIteratorFactory(),
-              new AscendingFacetTermIteratorFactory());
+          termVals = BidirectionalFacetResponseBuilder.build(env, dff.targetDoc != null);
         } catch (IOException ex) {
           throw new RuntimeException(ex);
         }
@@ -1540,40 +1545,57 @@ public class FacetComponent extends SearchComponent {
         String name = shardCounts.getName(i);
         long count;
         Object val;
+        TermDocIterator tdi = null;
+        TermDocEntry next;
         if (fPayload != null) {
           Object rawVal = shardCounts.getVal(i);
           if (rawVal instanceof Number) {
             val = null;
             count = ((Number)rawVal).longValue();
-          } else {
+          } else if (targetDoc == null) {
             val = rawVal;
             count = fPayload.extractCount(val);
+          } else {
+            NamedList<Object> termEntry = (NamedList<Object>)rawVal;
+            NamedList<SolrDocument> docs = (NamedList<SolrDocument>)termEntry.remove(termEntry.size() - 1);
+            if (name == null) {
+              val = null;
+              count = docs.size();
+            } else {
+              tdi = new TermDocIterator(name, docs.iterator(), termEntry);
+              val = next = tdi.next();
+              name = next.termDocId;
+              count = 1;
+            }
           }
         } else {
           val = null;
-          count = ((Number) shardCounts.getVal(i)).longValue();
+          count = ((Number)shardCounts.getVal(i)).longValue();
         }
-        if (name == null) {
-          missingCount += count;
-          numReceived--;
-        } else {
-          ShardFacetCount sfc = counts.get(name);
-          if (sfc == null) {
-            sfc = new ShardFacetCount();
-            sfc.name = name;
-            sfc.indexed = ftype == null ? sfc.name : ftype.toInternal(sfc.name);
-            sfc.termNum = termNum++;
-            sfc.val = val;
-            counts.put(name, sfc);
-          } else if (fPayload != null) {
-            sfc.val = fPayload.mergePayload(sfc.val, val, sfc.count, count);
+        do {
+          if (name == null) {
+            missingCount += count;
+            numReceived--;
+          } else {
+            ShardFacetCount sfc = counts.get(name);
+            if (sfc == null) {
+              sfc = new ShardFacetCount();
+              sfc.name = name;
+              sfc.indexed = ftype == null ? sfc.name : ftype.toInternal(sfc.name);
+              sfc.termNum = termNum++;
+              sfc.val = val;
+              counts.put(name, sfc);
+            } else if (fPayload != null) {
+              sfc.val = fPayload.mergePayload(sfc.val, val, sfc.count, count);
+            }
+            sfc.count += count;
+            terms.set(sfc.termNum);
+            last = count;
           }
-          sfc.count += count;
-          terms.set(sfc.termNum);
-          last = count;
-        }
+        } while (tdi != null && tdi.hasNext()
+            && assign(true, val = next = tdi.next(), name = next.termDocId));
       }
-      
+
       // the largest possible missing term is initialMincount if we received
       // less than the number requested.
       if (numRequested < 0 || numRequested != 0 && numReceived < numRequested) {
@@ -1585,6 +1607,52 @@ public class FacetComponent extends SearchComponent {
       counted[shardNum] = terms;
     }
     
+    private static boolean assign(boolean retVal, Object... vals) {
+      return retVal;
+    }
+
+    private static class TermDocIterator implements Iterator<TermDocEntry> {
+
+      private final String term;
+      private final Iterator<Entry<String, SolrDocument>> docs;
+      private final NamedList<Object> termMetadata;
+
+      public TermDocIterator(String term, Iterator<Entry<String, SolrDocument>> docs, NamedList<Object> termMetadata) {
+        this.term = term;
+        this.docs = docs;
+        this.termMetadata = termMetadata;
+      }
+
+      @Override
+      public boolean hasNext() {
+        return docs.hasNext();
+      }
+
+      @Override
+      public TermDocEntry next() {
+        Entry<String, SolrDocument> next = docs.next();
+        return new TermDocEntry(term, next.getKey(), termMetadata, next.getValue());
+      }
+
+    }
+
+    public static class TermDocEntry {
+      public final String term;
+      public final String docId;
+      public final String termDocId;
+      public final NamedList<Object> termMetadata;
+      public final SolrDocument doc;
+
+      public TermDocEntry(String term, String docId, NamedList<Object> termMetadata, SolrDocument doc) {
+        this.term = term;
+        this.docId = docId;
+        this.termDocId = term.concat(docId);
+        this.termMetadata = termMetadata;
+        this.doc = doc;
+      }
+
+    }
+
     public ShardFacetCount[] getLexSorted() {
       ShardFacetCount[] arr 
         = counts.values().toArray(new ShardFacetCount[counts.size()]);

--- a/src/main/java/org/apache/solr/handler/component/FacetComponent.java
+++ b/src/main/java/org/apache/solr/handler/component/FacetComponent.java
@@ -1178,7 +1178,8 @@ public class FacetComponent extends SearchComponent {
       } else {
         // index order with target/offset
         int targetIdx = Arrays.binarySearch(counts, dff.target, (o1, o2) -> o1.indexed.compareTo(o2.indexed));
-        Env env = new DistribEnv(dff.offset, dff.limit, targetIdx, dff.targetDoc,
+        System.err.println("XXX "+dff.offset+", "+dff.limit+", "+counts.length+", "+targetIdx+", "+dff.target.indexed);
+        Env env = new DistribEnv(dff.offset, dff.limit, targetIdx,
             dff.minCount, dff.field, dff.ftype, fieldCounts, counts);
         try {
           termVals = BidirectionalFacetResponseBuilder.build(env, new DescendingFacetTermIteratorFactory(),

--- a/src/main/java/org/apache/solr/request/BidirectionalFacetResponseBuilder.java
+++ b/src/main/java/org/apache/solr/request/BidirectionalFacetResponseBuilder.java
@@ -232,6 +232,7 @@ public class BidirectionalFacetResponseBuilder<T extends FieldType & FacetPayloa
     @Override
     public boolean init() {
       if ((facetKey = limitMinder.startKey()) != null) {
+        env.initState(facetKey);
         adjustOffset();
         return true;
       } else {
@@ -397,6 +398,7 @@ public class BidirectionalFacetResponseBuilder<T extends FieldType & FacetPayloa
     public final int mincount;
     public final String fieldName;
     public final T ft;
+    public final String ftDelim;
     public final NamedList res;
 
     public Env(int offset, int limit, int targetIdx, int mincount, String fieldName, T ft, NamedList res) {
@@ -406,6 +408,11 @@ public class BidirectionalFacetResponseBuilder<T extends FieldType & FacetPayloa
       this.mincount = mincount;
       this.fieldName = fieldName;
       this.ft = ft;
+      if (ft instanceof MultiSerializable) {
+        ftDelim = ((MultiSerializable)ft).getDelim();
+      } else {
+        ftDelim = "\u0000";
+      }
       this.res = res;
     }
     
@@ -418,6 +425,8 @@ public class BidirectionalFacetResponseBuilder<T extends FieldType & FacetPayloa
     public abstract K targetKey() throws IOException;
 
     public abstract K targetKeyInit(boolean ascending) throws IOException;
+
+    public abstract void initState(K key);
 
   }
   
@@ -491,6 +500,11 @@ public class BidirectionalFacetResponseBuilder<T extends FieldType & FacetPayloa
 
     private boolean acceptTerm(int i) {
       return counts[i].count >= mincount;
+    }
+
+    @Override
+    public void initState(SimpleTermIndexKey key) {
+      // stub ... no action necessary.
     }
 
   }
@@ -654,6 +668,11 @@ public class BidirectionalFacetResponseBuilder<T extends FieldType & FacetPayloa
       } else {
         return facetKey = new SimpleTermIndexKey(index);
       }
+    }
+
+    @Override
+    public void initState(SimpleTermIndexKey key) {
+      // stub ... no action necessary?
     }
 
   }

--- a/src/main/java/org/apache/solr/request/BidirectionalFacetResponseBuilder.java
+++ b/src/main/java/org/apache/solr/request/BidirectionalFacetResponseBuilder.java
@@ -26,7 +26,9 @@ import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.CharsRefBuilder;
+import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.util.NamedList;
+import org.apache.solr.handler.component.FacetComponent.DistribFieldFacet.TermDocEntry;
 import org.apache.solr.handler.component.FacetComponent.ShardFacetCount;
 import org.apache.solr.request.BidirectionalFacetResponseBuilder.FacetKey;
 import org.apache.solr.schema.FieldType;
@@ -38,7 +40,9 @@ import org.apache.solr.search.SolrIndexSearcher;
  */
 public class BidirectionalFacetResponseBuilder<T extends FieldType & FacetPayload, K extends FacetKey<K>> {
 
-  public static <T extends FieldType & FacetPayload, K extends FacetKey<K>> NamedList<Object> build(Env<T, K> env, OuterIteratorFactory<T, K> outer, InnerIteratorFactory<T, K> inner) throws IOException {
+  public static <T extends FieldType & FacetPayload, K extends FacetKey<K>> NamedList<Object> build(Env<T, K> env, boolean doc) throws IOException {
+    OuterIteratorFactory<T, K> outer = new DescendingFacetTermIteratorFactory(doc);
+    InnerIteratorFactory<T, K> inner = new AscendingFacetTermIteratorFactory(doc);
     Deque<Entry<String, Object>> entryBuilder = new ArrayDeque<>(Math.min(env.limit, 1000));
     int actualOffset;
     FacetResultIterator fri;
@@ -47,22 +51,25 @@ public class BidirectionalFacetResponseBuilder<T extends FieldType & FacetPayloa
     } else {
       fri = inner.initialInstance(env, outer);
     }
+    int size = 0;
     do {
       if (fri.init()) {
         do {
-          fri.addEntry(entryBuilder);
+          if (fri.addEntry(entryBuilder, size)) {
+            size++;
+          }
         } while (fri.hasNextEntry());
       }
       actualOffset = fri.getActualOffset();
-      fri = fri.nextIterator(entryBuilder.size());
+      fri = fri.nextIterator(size);
     } while (fri != null);
     NamedList res = env.res;
-    int size = entryBuilder.size();
     res.add("count", size);
     if (size > 0) {
       res.add("target_offset", actualOffset);
     }
-    NamedList<Object> ret = new NamedList<Object>(entryBuilder.toArray(new Entry[size]));
+    NamedList<Object> ret = new NamedList<>(entryBuilder.toArray(new Entry[entryBuilder.size()]));
+    ret = env.finalize(ret);
     res.add("terms", ret);
     return ret;
   }
@@ -80,7 +87,7 @@ public class BidirectionalFacetResponseBuilder<T extends FieldType & FacetPayloa
   public static interface FacetResultIterator<T extends FieldType & FacetPayload> {
     boolean init();
     boolean hasNextEntry();
-    void addEntry(Deque<Entry<String, Object>> entryBuilder) throws IOException;
+    boolean addEntry(Deque<Entry<String, Object>> entryBuilder, int size) throws IOException;
     int getActualOffset();
     FacetResultIterator<T> nextIterator(int currentSize) throws IOException;
   }
@@ -89,9 +96,16 @@ public class BidirectionalFacetResponseBuilder<T extends FieldType & FacetPayloa
 
   public static class AscendingFacetTermIteratorFactory<T extends FieldType & FacetPayload, K extends FacetKey<K>> implements InnerIteratorFactory<T, K> {
 
+    private final boolean doc;
+
+    public AscendingFacetTermIteratorFactory(boolean doc) {
+      this.doc = doc;
+    }
+
     @Override
     public FacetResultIterator<T> initialInstance(Env<T, K> env, OuterIteratorFactory<T, K> outer) throws IOException {
-      return newInstance(0, env.decrementKey(env.targetKey()), 0, env, outer);
+      K targetKey = env.targetKey();
+      return newInstance(0, env.decrementKey(targetKey), 0, env, outer);
     }
 
     @Override
@@ -108,7 +122,12 @@ public class BidirectionalFacetResponseBuilder<T extends FieldType & FacetPayloa
         lim = env.limit - actualOffsetInit;
         provisional = Provisional.NEVER;
       }
-      LimitMinder<T, K> limitMinder = new IncrementingLimitMinder(env.targetKeyInit(true));
+      LimitMinder<T, K> limitMinder;
+      if (doc) {
+        limitMinder = new IncrementingDocLimitMinder(env.targetKeyInit(true));
+      } else {
+        limitMinder = new IncrementingLimitMinder(env.targetKeyInit(true));
+      }
       return new AscendingFacetTermIterator<>(provisional, limitMinder, actualOffsetInit, off, lim, descentStartIdx, env, outer);
     }
     
@@ -121,7 +140,7 @@ public class BidirectionalFacetResponseBuilder<T extends FieldType & FacetPayloa
     
     private AscendingFacetTermIterator(Provisional provisionalInit, LimitMinder limitMinder, int actualOffsetInit, int off, int lim,
         K descentStartIdx, Env<T, K> env, OuterIteratorFactory<T, K> next) {
-      super(limitMinder, actualOffsetInit + 1, provisionalInit, off, lim, env);
+      super(limitMinder, actualOffsetInit, provisionalInit, off, lim, env);
       this.descentStartIdx = descentStartIdx;
       this.next = next;
     }
@@ -136,20 +155,37 @@ public class BidirectionalFacetResponseBuilder<T extends FieldType & FacetPayloa
     }
 
     @Override
-    protected void adjustOffset() {
-      actualOffset--;
+    protected boolean adjustOffset(int size, int limit, Deque<Entry<String, Object>> entryBuilder) {
+      if (size < limit) {
+        return false;
+      } else {
+        limitMinder.removeTail(entryBuilder);
+        actualOffset--;
+        return true;
+      }
     }
 
   }
 
   public static class DescendingFacetTermIteratorFactory<T extends FieldType & FacetPayload, K extends FacetKey<K>> implements OuterIteratorFactory<T, K> {
 
+    private final boolean doc;
+
+    public DescendingFacetTermIteratorFactory(boolean doc) {
+      this.doc = doc;
+    }
+
     @Override
     public FacetResultIterator<T> initialInstance(Env<T, K> env, InnerIteratorFactory<T, K> inner, OuterIteratorFactory<T, K> outer) throws IOException {
       boolean finalDescent = false;
-      int actualOffsetInit = 1;
+      int actualOffsetInit = 0;
       K startIndex = env.decrementKey(env.targetKey());
-      LimitMinder<T, K> limitMinder = new DecrementingLimitMinder(startIndex);
+      LimitMinder<T, K> limitMinder;
+      if (doc) {
+        limitMinder = new DecrementingDocLimitMinder(startIndex);
+      } else {
+        limitMinder = new DecrementingLimitMinder(startIndex);
+      }
       int off;
       int lim;
       Provisional provisionalInit;
@@ -168,7 +204,12 @@ public class BidirectionalFacetResponseBuilder<T extends FieldType & FacetPayloa
     @Override
     public FacetResultIterator<T> finalInstance(K startIndex, int actualOffsetInit, int size, Env<T, K> env) throws IOException {
       boolean finalDescent = true;
-      LimitMinder<T, K> limitMinder = new DecrementingLimitMinder(startIndex);
+      LimitMinder<T, K> limitMinder;
+      if (doc) {
+        limitMinder = new DecrementingDocLimitMinder(startIndex);
+      } else {
+        limitMinder = new DecrementingLimitMinder(startIndex);
+      }
       int lim = env.limit - size;
       return new DescendingFacetTermIterator<>(limitMinder, actualOffsetInit, Provisional.NEVER, 0, lim, env, finalDescent, null, null);
     }
@@ -183,7 +224,7 @@ public class BidirectionalFacetResponseBuilder<T extends FieldType & FacetPayloa
     
     private DescendingFacetTermIterator(LimitMinder<T, K> limitMinder, int actualOffsetInit, Provisional provisionalInit, int off, int lim, Env<T, K> env,
         boolean finalDescent, InnerIteratorFactory<T, K> inner, OuterIteratorFactory<T, K> outer) {
-      super(limitMinder, actualOffsetInit - 1, provisionalInit, off, lim, env);
+      super(limitMinder, actualOffsetInit, provisionalInit, off, lim, env);
       this.finalDescent = finalDescent;
       this.inner = inner;
       this.outer = outer;
@@ -203,8 +244,14 @@ public class BidirectionalFacetResponseBuilder<T extends FieldType & FacetPayloa
     }
 
     @Override
-    protected void adjustOffset() {
+    protected boolean adjustOffset(int size, int limit, Deque<Entry<String, Object>> entryBuilder) {
       actualOffset++;
+      if (size < limit) {
+        return false;
+      } else {
+        limitMinder.removeTail(entryBuilder);
+        return true;
+      }
     }
 
   }
@@ -212,7 +259,7 @@ public class BidirectionalFacetResponseBuilder<T extends FieldType & FacetPayloa
   public static abstract class BaseFacetTermIterator<T extends FieldType & FacetPayload, K extends FacetKey<K>> implements FacetResultIterator<T> {
     
     protected K facetKey;
-    private final LimitMinder<T, K> limitMinder;
+    protected final LimitMinder<T, K> limitMinder;
     protected int actualOffset;
     private int off;
     private int lim;
@@ -233,7 +280,6 @@ public class BidirectionalFacetResponseBuilder<T extends FieldType & FacetPayloa
     public boolean init() {
       if ((facetKey = limitMinder.startKey()) != null) {
         env.initState(facetKey);
-        adjustOffset();
         return true;
       } else {
         return false;
@@ -245,24 +291,33 @@ public class BidirectionalFacetResponseBuilder<T extends FieldType & FacetPayloa
       if (exhausted) {
         return false;
       } else {
-        return (facetKey = limitMinder.nextKey(facetKey, env)) != null;
+        K blah = facetKey;
+        facetKey = limitMinder.nextKey(facetKey, env);
+        return facetKey != null;
       }
     }
 
-    protected boolean preAddEntry(Deque<Entry<String, Object>> entryBuilder) {
+    protected boolean preAddEntry(Deque<Entry<String, Object>> entryBuilder, int size) {
+      boolean ret = true;
       if (provisional == Provisional.PROVISIONAL) {
         if (--off < 0) {
           provisional = Provisional.SATISFIED;
         }
-        if (entryBuilder.size() >= env.limit) {
-          entryBuilder.removeFirst();
-          adjustOffset();
-        }
       }
-      return true;
+      if (adjustOffset(size, env.limit, entryBuilder)) {
+        ret = false;
+      }
+      return ret;
     }
     
-    protected abstract void adjustOffset();
+    /**
+     * 
+     * @param size
+     * @param limit
+     * @param entryBuilder
+     * @return false if size remains the same.
+     */
+    protected abstract boolean adjustOffset(int size, int limit, Deque<Entry<String, Object>> entryBuilder);
 
     protected boolean postAddEntry(Deque<Entry<String, Object>> entryBuilder) {
       switch (provisional) {
@@ -277,13 +332,13 @@ public class BidirectionalFacetResponseBuilder<T extends FieldType & FacetPayloa
     }
 
     @Override
-    public void addEntry(Deque<Entry<String, Object>> entryBuilder) throws IOException {
-      if (preAddEntry(entryBuilder)) {
-        innerAddEntry(entryBuilder);
-        if (postAddEntry(entryBuilder)) {
-          exhausted = true;
-        }
+    public boolean addEntry(Deque<Entry<String, Object>> entryBuilder, int size) throws IOException {
+      boolean ret = preAddEntry(entryBuilder, size);
+      innerAddEntry(entryBuilder);
+      if (postAddEntry(entryBuilder)) {
+        exhausted = true;
       }
+      return ret;
     }
     
     protected void innerAddEntry(Deque<Entry<String, Object>> entryBuilder) throws IOException {
@@ -306,6 +361,8 @@ public class BidirectionalFacetResponseBuilder<T extends FieldType & FacetPayloa
     K startKey();
     K nextKey(K lastKey, Env<T, K> env);
     void addEntry(Entry<String, Object> entry, Deque<Entry<String, Object>> entryBuilder);
+    boolean updateEntry(String term, String docId, SolrDocument doc, Deque<Entry<String, Object>> entryBuilder);
+    void removeTail(Deque<Entry<String, Object>> entryBuilder);
   }
   
   private static abstract class AbstractLimitMinder<T extends FieldType & FacetPayload, K extends FacetKey<K>> implements LimitMinder<T, K> {
@@ -338,9 +395,50 @@ public class BidirectionalFacetResponseBuilder<T extends FieldType & FacetPayloa
     public void addEntry(Entry<String, Object> entry, Deque<Entry<String, Object>> entryBuilder) {
       entryBuilder.addLast(entry);
     }
-    
+
+    @Override
+    public boolean updateEntry(String term, String docId, SolrDocument doc, Deque<Entry<String, Object>> entryBuilder) {
+      return false;
+    }
+
+    @Override
+    public void removeTail(Deque<Entry<String, Object>> entryBuilder) {
+      entryBuilder.removeFirst();
+    }
+
   }
   
+  private static class IncrementingDocLimitMinder<T extends FieldType & FacetPayload, K extends FacetKey<K>> extends IncrementingLimitMinder<T, K> {
+
+    public IncrementingDocLimitMinder(K startIndex) {
+      super(startIndex);
+    }
+
+    @Override
+    public boolean updateEntry(String term, String docId, SolrDocument doc, Deque<Entry<String, Object>> entryBuilder) {
+      Entry<String, Object> last;
+      if (!entryBuilder.isEmpty() && term.equals((last = entryBuilder.getLast()).getKey())) {
+        NamedList<Object> lastVal = (NamedList<Object>)last.getValue();
+        Deque<Entry<String, Object>> docDeque = (Deque<Entry<String, Object>>) lastVal.getVal(lastVal.size() - 1);
+        docDeque.addLast(new SimpleImmutableEntry<>(docId, doc));
+        return true;
+      }
+      return false;
+    }
+
+    @Override
+    public void removeTail(Deque<Entry<String, Object>> entryBuilder) {
+      Entry<String, Object> first = entryBuilder.getFirst();
+      NamedList<Object> firstVal = (NamedList<Object>)first.getValue();
+      Deque<Entry<String, Object>> docDeque = (Deque<Entry<String, Object>>)firstVal.getVal(firstVal.size() - 1);
+      if (docDeque.size() > 1) {
+        docDeque.removeFirst();
+      } else {
+        entryBuilder.removeFirst();
+      }
+    }
+  }
+
   private static class DecrementingLimitMinder<T extends FieldType & FacetPayload, K extends FacetKey<K>> extends AbstractLimitMinder<T, K> {
 
     public DecrementingLimitMinder(K startIndex) {
@@ -356,9 +454,50 @@ public class BidirectionalFacetResponseBuilder<T extends FieldType & FacetPayloa
     public void addEntry(Entry<String, Object> entry, Deque<Entry<String, Object>> entryBuilder) {
       entryBuilder.addFirst(entry);
     }
-    
+
+    @Override
+    public boolean updateEntry(String term, String docId, SolrDocument doc, Deque<Entry<String, Object>> entryBuilder) {
+      return false;
+    }
+
+    @Override
+    public void removeTail(Deque<Entry<String, Object>> entryBuilder) {
+      entryBuilder.removeLast();
+    }
+
   }
-  
+
+  private static class DecrementingDocLimitMinder<T extends FieldType & FacetPayload, K extends FacetKey<K>> extends DecrementingLimitMinder<T, K> {
+
+    public DecrementingDocLimitMinder(K startIndex) {
+      super(startIndex);
+    }
+
+    @Override
+    public boolean updateEntry(String term, String docId, SolrDocument doc, Deque<Entry<String, Object>> entryBuilder) {
+      Entry<String, Object> previous;
+      if (!entryBuilder.isEmpty() && term.equals((previous = entryBuilder.getFirst()).getKey())) {
+        NamedList<Object> previousVal = (NamedList<Object>)previous.getValue();
+        Deque<Entry<String, Object>> docDeque = (Deque<Entry<String, Object>>) previousVal.getVal(previousVal.size() - 1);
+        docDeque.addFirst(new SimpleImmutableEntry<>(docId, doc));
+        return true;
+      }
+      return false;
+    }
+
+    @Override
+    public void removeTail(Deque<Entry<String, Object>> entryBuilder) {
+      Entry<String, Object> last = entryBuilder.getLast();
+      NamedList<Object> lastVal = (NamedList<Object>)last.getValue();
+      Deque<Entry<String, Object>> docDeque = (Deque<Entry<String, Object>>)lastVal.getVal(lastVal.size() - 1);
+      if (docDeque.size() > 1) {
+        docDeque.removeLast();
+      } else {
+        entryBuilder.removeLast();
+      }
+    }
+  }
+
   public static interface FacetKey<K extends FacetKey<K>> extends Comparable<K> {
     
   }
@@ -428,11 +567,53 @@ public class BidirectionalFacetResponseBuilder<T extends FieldType & FacetPayloa
 
     public abstract void initState(K key);
 
+    public NamedList<Object> finalize(NamedList<Object> ret) {
+      return ret;
+    }
+
   }
   
+  public static class DistribDocEnv<T extends FieldType & FacetPayload> extends DistribEnv<T> {
+
+    public DistribDocEnv(int offset, int limit, int targetIdx, int mincount, String fieldName, T ft, NamedList res, ShardFacetCount[] counts) {
+      super(offset, limit, targetIdx, mincount, fieldName, ft, res, counts);
+    }
+
+    @Override
+    public void addEntry(LimitMinder<T, SimpleTermIndexKey> limitMinder, SimpleTermIndexKey facetKey, Deque<Entry<String, Object>> entryBuilder) throws IOException {
+      ShardFacetCount sfc = counts[facetKey.index];
+      TermDocEntry val = (TermDocEntry)sfc.val;
+      String currentTerm = val.term;
+      String docIdStr = val.docId;
+      SolrDocument doc = val.doc;
+      if (!limitMinder.updateEntry(currentTerm, docIdStr, doc, entryBuilder)) {
+        Deque<Entry<String, SolrDocument>> docDeque = new ArrayDeque<>(4);
+        docDeque.add(new SimpleImmutableEntry<>(docIdStr, doc));
+        NamedList<Object> termEntry = val.termMetadata;
+        termEntry.add("docs", docDeque);
+        Entry<String, Object> entry = new SimpleImmutableEntry<>(currentTerm, termEntry);
+        limitMinder.addEntry(entry, entryBuilder);
+      }
+    }
+
+    @Override
+    public NamedList<Object> finalize(NamedList<Object> ret) {
+      ret = super.finalize(ret);
+      for (int i = 0; i < ret.size(); i++) {
+        NamedList<Object> termEntry = (NamedList<Object>)ret.getVal(i);
+        int docsIdx = termEntry.size() - 1;
+        Deque<Entry<String, SolrDocument>> docDeque = (Deque<Entry<String, SolrDocument>>)termEntry.getVal(docsIdx);
+        NamedList<SolrDocument> docsExternal = new NamedList(docDeque.toArray(new Entry[docDeque.size()]));
+        termEntry.setVal(docsIdx, docsExternal);
+      }
+      return ret;
+    }
+
+  }
+
   public static class DistribEnv<T extends FieldType & FacetPayload> extends Env<T, SimpleTermIndexKey> {
 
-    private final ShardFacetCount[] counts;
+    protected final ShardFacetCount[] counts;
 
     public DistribEnv(int offset, int limit, int targetIdx, int mincount, String fieldName, T ft,
         NamedList res, ShardFacetCount[] counts) {
@@ -592,7 +773,7 @@ public class BidirectionalFacetResponseBuilder<T extends FieldType & FacetPayloa
     }
 
     protected final int getTargetKeyIndex() {
-      return (targetIdx < 0 ? ~targetIdx : targetIdx) + adjust;
+      return (targetIdx < 0 ? ~targetIdx : targetIdx);
     }
 
     protected final int getTargetKeyIndexInit(boolean ascending) {
@@ -641,7 +822,7 @@ public class BidirectionalFacetResponseBuilder<T extends FieldType & FacetPayloa
     @Override
     public void addEntry(LimitMinder<T, SimpleTermIndexKey> limitMinder, SimpleTermIndexKey facetKey, Deque<Entry<String, Object>> entryBuilder) throws IOException {
       if (facetKey != this.facetKey) {
-        throw new IllegalStateException();
+        throw new IllegalStateException(facetKey +" != "+this.facetKey);
       }
       Entry<String, Object> entry;
       if (!extend) {
@@ -672,7 +853,12 @@ public class BidirectionalFacetResponseBuilder<T extends FieldType & FacetPayloa
 
     @Override
     public void initState(SimpleTermIndexKey key) {
-      // stub ... no action necessary?
+      if (this.facetKey != key) {
+        if (!acceptTerm(key.index)) {
+          throw new IllegalStateException();
+        }
+        this.facetKey = key;
+      }
     }
 
   }

--- a/src/main/java/org/apache/solr/request/BidirectionalFacetResponseBuilder.java
+++ b/src/main/java/org/apache/solr/request/BidirectionalFacetResponseBuilder.java
@@ -123,10 +123,11 @@ public class BidirectionalFacetResponseBuilder<T extends FieldType & FacetPayloa
         provisional = Provisional.NEVER;
       }
       LimitMinder<T, K> limitMinder;
+      K targetKeyInit = env.targetKeyInit(true);
       if (doc) {
-        limitMinder = new IncrementingDocLimitMinder(env.targetKeyInit(true));
+        limitMinder = new IncrementingDocLimitMinder(targetKeyInit);
       } else {
-        limitMinder = new IncrementingLimitMinder(env.targetKeyInit(true));
+        limitMinder = new IncrementingLimitMinder(targetKeyInit);
       }
       return new AscendingFacetTermIterator<>(provisional, limitMinder, actualOffsetInit, off, lim, descentStartIdx, env, outer);
     }
@@ -590,7 +591,10 @@ public class BidirectionalFacetResponseBuilder<T extends FieldType & FacetPayloa
       if (!limitMinder.updateEntry(currentTerm, docIdStr, doc, entryBuilder)) {
         Deque<Entry<String, SolrDocument>> docDeque = new ArrayDeque<>(4);
         docDeque.add(new SimpleImmutableEntry<>(docIdStr, doc));
-        NamedList<Object> termEntry = val.termMetadata;
+        NamedList<Object> termEntry = new NamedList<>(2);
+        if (val.termMetadata != null) {
+          termEntry.add("termMetadata", val.termMetadata);
+        }
         termEntry.add("docs", docDeque);
         Entry<String, Object> entry = new SimpleImmutableEntry<>(currentTerm, termEntry);
         limitMinder.addEntry(entry, entryBuilder);

--- a/src/main/java/org/apache/solr/request/BidirectionalFacetResponseBuilder.java
+++ b/src/main/java/org/apache/solr/request/BidirectionalFacetResponseBuilder.java
@@ -235,7 +235,8 @@ public class BidirectionalFacetResponseBuilder<T extends FieldType & FacetPayloa
       if (finalDescent) {
         return null;
       } else if (actualOffset < env.limit) {
-        return inner.newInstance(actualOffset, facetKey, size, env, outer);
+        K resumeDescent = facetKey == null ? null : limitMinder.nextKey(facetKey, env);
+        return inner.newInstance(actualOffset, resumeDescent, size, env, outer);
       } else if (size < env.limit) {
         return outer.finalInstance(facetKey, actualOffset, size, env);
       } else {

--- a/src/main/java/org/apache/solr/request/DocBasedFacetResponseBuilder.java
+++ b/src/main/java/org/apache/solr/request/DocBasedFacetResponseBuilder.java
@@ -282,9 +282,9 @@ public class DocBasedFacetResponseBuilder {
       int rawTargetIdx = getTargetKeyIndex();
       BytesRef initTargetDoc = targetDoc;
       if (rawTargetIdx < termIndex) {
-        initTargetDoc = UnicodeUtil.BIG_TERM;
-      } else if (rawTargetIdx > termIndex) {
         initTargetDoc = null;
+      } else if (rawTargetIdx > termIndex) {
+        initTargetDoc = UnicodeUtil.BIG_TERM;
       }
       TermDocIndexKey ret = new TermDocIndexKey(termIndex, initTargetDoc);
       int docIndex = acceptDoc(termIndex, initTargetDoc);

--- a/src/main/java/org/apache/solr/request/DocBasedFacetResponseBuilder.java
+++ b/src/main/java/org/apache/solr/request/DocBasedFacetResponseBuilder.java
@@ -1,0 +1,257 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.request;
+
+import java.io.IOException;
+import java.util.AbstractMap.SimpleImmutableEntry;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Deque;
+import java.util.Map;
+import java.util.Map.Entry;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.index.SortedSetDocValues;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.Sort;
+import org.apache.lucene.search.SortField;
+import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.CharsRefBuilder;
+import org.apache.lucene.util.UnicodeUtil;
+import org.apache.solr.common.util.NamedList;
+import org.apache.solr.request.BidirectionalFacetResponseBuilder.BaseLocalTermEnv;
+import org.apache.solr.request.BidirectionalFacetResponseBuilder.BaseTermIndexKey;
+import org.apache.solr.request.BidirectionalFacetResponseBuilder.LimitMinder;
+import org.apache.solr.schema.FieldType;
+import org.apache.solr.schema.SchemaField;
+import org.apache.solr.search.DocList;
+import org.apache.solr.search.DocSet;
+import org.apache.solr.search.SolrIndexSearcher;
+
+/**
+ *
+ * @author magibney
+ */
+public class DocBasedFacetResponseBuilder {
+  
+  public static class TermDocIndexKey extends BaseTermIndexKey<TermDocIndexKey> {
+
+    public final BytesRef docId;
+    
+    public TermDocIndexKey(int index, BytesRef docId) {
+      super(index);
+      this.docId = docId;
+    }
+
+    @Override
+    public String toString() {
+      return TermDocIndexKey.class.getSimpleName() + "(index=" + index + ", docId=" + docId + ')';
+    }
+    
+  }
+  
+  public static class LocalDocEnv<T extends FieldType & FacetPayload> extends BaseLocalTermEnv<T, TermDocIndexKey> {
+
+    private final BytesRef targetDoc;
+    private final DocSet docs;
+    private final Sort sort;
+    private final SortField sortField;
+    private final Comparator<BytesRef> idFieldComparator;
+    private final String idField;
+    
+    private TermDocIndexKey termDocIndexKey;
+    
+    private int activeTermIndex = -1;
+    private Document[] documents = null;
+    private BytesRef[] docIds = null;
+    
+    private int localDocIndex = -1;
+
+    public LocalDocEnv(int offset, int limit, int startTermIndex, int adjust, int targetIdx, String targetDoc, int nTerms,
+        String contains, boolean ignoreCase, int mincount, int[] counts, CharsRefBuilder charsRef, boolean extend,
+        SortedSetDocValues si, SolrIndexSearcher searcher, DocSet docs, String fieldName, T ft, NamedList res) {
+      super(offset, limit, startTermIndex, adjust, targetIdx, nTerms, contains, ignoreCase, mincount, counts,
+          charsRef, extend, si, searcher, fieldName, ft, res);
+      SchemaField uniqueKeyField = searcher.getSchema().getUniqueKeyField();
+      this.targetDoc = new BytesRef(targetDoc);
+      this.idField = uniqueKeyField.getName();
+      this.sortField = uniqueKeyField.getSortField(true);
+      this.idFieldComparator = this.sortField.getBytesComparator();
+      this.sort = new Sort(sortField);
+      this.docs = docs;
+    }
+    
+    private boolean initTermIndex(int termIndex) {
+      if (currentTermBytes == null) {
+        if (termIndex < adjust || termIndex >= nTerms || !acceptTerm(termIndex)) {
+          return false;
+        }
+      }
+      try {
+        //TODO get this some other way.
+        Query q = new TermQuery(new Term(fieldName, currentTermBytes));
+        DocList docList = searcher.getDocList(q, docs, sort, 0, Integer.MAX_VALUE); //TODO page through? avoid OOM for large doc counts?
+        int size = docList.size();
+        if (size <= 0) {
+          return false;
+        }
+        activeTermIndex = termIndex;
+        documents = new Document[size];
+        docIds = new BytesRef[size];
+        searcher.readDocs(documents, docList, Collections.singleton(idField));
+        localDocIndex = -1;
+        for (int i = 0; i < size; i++) {
+          docIds[i] = new BytesRef(documents[i].get(idField));
+        }
+        return true;
+      } catch (IOException ex) {
+        throw new RuntimeException(ex);
+      }
+    }
+        
+    private int acceptDoc(int termIndex, BytesRef docId) {
+      if (activeTermIndex != termIndex) {
+        if (!initTermIndex(termIndex)) {
+          return -1;
+        }
+      }
+      return docIndex(docId);
+    }
+    
+    private int docIndex(BytesRef docId) {
+      if (localDocIndex >= 0 && localDocIndex < docIds.length && docId.bytesEquals(docIds[localDocIndex])) {
+        return localDocIndex;
+      }
+      return Arrays.binarySearch(docIds, docId, idFieldComparator);
+    }
+    
+    private BytesRef incrementDocId(int termIndex, BytesRef lastDocId) {
+      if (activeTermIndex != termIndex) {
+        if (!initTermIndex(termIndex)) {
+          return null;
+        }
+      }
+      int lastDocIndex = docIndex(lastDocId);
+      int nextDocIndex;
+      if (lastDocIndex < 0) {
+        nextDocIndex = ~lastDocIndex;
+      } else {
+        nextDocIndex = lastDocIndex + 1;
+      }
+      if (nextDocIndex < docIds.length) {
+        localDocIndex = nextDocIndex;
+        return docIds[nextDocIndex];
+      } else {
+        localDocIndex = -1;
+        return null;
+      }
+    }
+
+    @Override
+    public TermDocIndexKey incrementKey(TermDocIndexKey previousKey) {
+      int termIndex = previousKey.index;
+      BytesRef docId = previousKey.docId;
+      do {
+        while ((docId = incrementDocId(termIndex, docId)) != null) {
+          int docIndex = acceptDoc(termIndex, docId);
+          if (docIndex >= 0) {
+            localDocIndex = docIndex;
+            return termDocIndexKey = new TermDocIndexKey(termIndex, docId);
+          }
+        }
+        docId = new BytesRef(BytesRef.EMPTY_BYTES);
+      } while ((termIndex = incrementTermIndex(termIndex)) >= 0);
+      return null;
+    }
+    
+    private BytesRef decrementDocId(int termIndex, BytesRef lastDocId) {
+      if (activeTermIndex != termIndex) {
+        if (!initTermIndex(termIndex)) {
+          return null;
+        }
+      }
+      int nextDocIndex = docIndex(lastDocId) - 1;
+      if (nextDocIndex >= 0) {
+        localDocIndex = nextDocIndex;
+        return docIds[nextDocIndex];
+      } else {
+        localDocIndex = -1;
+        return null;
+      }
+    }
+
+    @Override
+    public TermDocIndexKey decrementKey(TermDocIndexKey previousKey) {
+      int termIndex = previousKey.index;
+      BytesRef docId = previousKey.docId;
+      do {
+        while ((docId = decrementDocId(termIndex, docId)) != null) {
+          int docIndex = acceptDoc(termIndex, docId);
+          if (docIndex >= 0) {
+            localDocIndex = docIndex;
+            return termDocIndexKey = new TermDocIndexKey(termIndex, docId);
+          }
+        }
+        docId = UnicodeUtil.BIG_TERM;
+      } while ((termIndex = decrementTermIndex(termIndex)) >= 0);
+      return null;
+    }
+
+    @Override
+    public void addEntry(LimitMinder<T, TermDocIndexKey> limitMinder, TermDocIndexKey facetKey, Deque<Map.Entry<String, Object>> entryBuilder) throws IOException {
+      if (termDocIndexKey != facetKey) {
+        throw new IllegalStateException();
+      }
+      String termDocTerm = currentTerm + '\u0000' + facetKey.docId.utf8ToString();
+      Entry<String, Object> entry = new SimpleImmutableEntry<>(termDocTerm, documents[localDocIndex]);
+      limitMinder.addEntry(entry, entryBuilder);
+    }
+
+    @Override
+    public TermDocIndexKey targetKey() throws IOException {
+      return new TermDocIndexKey(getTargetKeyIndex(), targetDoc);
+    }
+
+    @Override
+    public TermDocIndexKey targetKeyInit(boolean ascending) throws IOException {
+      int termIndex = getTargetKeyIndexInit(ascending);
+      if (termIndex < 0) {
+        return null;
+      }
+      int rawTargetIdx = getTargetKeyIndex();
+      BytesRef initTargetDoc = targetDoc;
+      if (rawTargetIdx < termIndex) {
+        initTargetDoc = UnicodeUtil.BIG_TERM;
+      } else if (rawTargetIdx > termIndex) {
+        initTargetDoc = new BytesRef(BytesRef.EMPTY_BYTES);
+      }
+      TermDocIndexKey ret = new TermDocIndexKey(termIndex, initTargetDoc);
+      int docIndex = acceptDoc(termIndex, initTargetDoc);
+      if (docIndex >= 0) {
+        localDocIndex = docIndex;
+        return termDocIndexKey = ret;
+      } else if (ascending) {
+        return incrementKey(ret);
+      } else {
+        return decrementKey(ret);
+      }
+    }
+
+  }
+}

--- a/src/main/java/org/apache/solr/request/DocBasedFacetResponseBuilder.java
+++ b/src/main/java/org/apache/solr/request/DocBasedFacetResponseBuilder.java
@@ -26,6 +26,7 @@ import java.util.Deque;
 import java.util.Map;
 import java.util.Map.Entry;
 import org.apache.lucene.document.Document;
+import org.apache.lucene.index.PostingsEnum;
 import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.Query;
@@ -249,6 +250,13 @@ public class DocBasedFacetResponseBuilder {
         Deque<Entry<String, SolrDocument>> docDeque = new ArrayDeque<>(4);
         docDeque.add(new SimpleImmutableEntry<>(docIdStr, doc));
         NamedList<Object> termEntry = new NamedList<>(4);
+        if (extend) {
+          PostingsEnum postings = searcher.getLeafReader().postings(new Term(fieldName, currentTermBytes), PostingsEnum.PAYLOADS);
+          Entry<String, Object> entry = ft.addEntry(currentTerm, currentTermCount, postings);
+          if (entry != null) {
+            termEntry.add("termMetadata", entry.getValue());
+          }
+        }
         termEntry.add("docs", docDeque);
         Entry<String, Object> entry = new SimpleImmutableEntry<>(currentTerm, termEntry);
         limitMinder.addEntry(entry, entryBuilder);

--- a/src/main/java/org/apache/solr/request/DocValuesFacets.java
+++ b/src/main/java/org/apache/solr/request/DocValuesFacets.java
@@ -32,7 +32,6 @@ import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.DocIdSet;
 import org.apache.lucene.search.DocIdSetIterator;
-import org.apache.lucene.search.Sort;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefBuilder;
 import org.apache.lucene.util.CharsRefBuilder;
@@ -40,8 +39,6 @@ import org.apache.lucene.util.LongValues;
 import org.apache.lucene.util.UnicodeUtil;
 import org.apache.solr.common.params.FacetParams;
 import org.apache.solr.common.util.NamedList;
-import org.apache.solr.request.BidirectionalFacetResponseBuilder.AscendingFacetTermIteratorFactory;
-import org.apache.solr.request.BidirectionalFacetResponseBuilder.DescendingFacetTermIteratorFactory;
 import org.apache.solr.request.BidirectionalFacetResponseBuilder.Env;
 import org.apache.solr.request.BidirectionalFacetResponseBuilder.LocalTermEnv;
 import org.apache.solr.request.DocBasedFacetResponseBuilder.LocalDocEnv;
@@ -254,7 +251,8 @@ public class DocValuesFacets {
           }
         }
         } else {
-          final int targetIdx = (int)si.lookupTerm(target);
+          int targetIdx = (int)si.lookupTerm(target);
+          System.err.println("my target idx: "+targetIdx+", target="+target.utf8ToString());
           Env env;
           if (targetDoc != null) {
             env = new LocalDocEnv(offset, limit, startTermIndex, adjust, targetIdx, targetDoc, nTerms, contains,
@@ -263,8 +261,7 @@ public class DocValuesFacets {
             env = new LocalTermEnv(offset, limit, startTermIndex, adjust, targetIdx, nTerms, contains,
                 ignoreCase, mincount, counts, charsRef, extend, si, searcher, fieldName, ft, res);
           }
-          BidirectionalFacetResponseBuilder.build(env, new DescendingFacetTermIteratorFactory(),
-              new AscendingFacetTermIteratorFactory());
+          BidirectionalFacetResponseBuilder.build(env, targetDoc != null);
         }
       }
     }

--- a/src/main/java/org/apache/solr/request/DocValuesFacets.java
+++ b/src/main/java/org/apache/solr/request/DocValuesFacets.java
@@ -252,7 +252,6 @@ public class DocValuesFacets {
         }
         } else {
           int targetIdx = (int)si.lookupTerm(target);
-          System.err.println("my target idx: "+targetIdx+", target="+target.utf8ToString());
           Env env;
           if (targetDoc != null) {
             env = new LocalDocEnv(offset, limit, startTermIndex, adjust, targetIdx, targetDoc, nTerms, contains,

--- a/src/main/java/org/apache/solr/request/DocValuesFacets.java
+++ b/src/main/java/org/apache/solr/request/DocValuesFacets.java
@@ -32,6 +32,7 @@ import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.DocIdSet;
 import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.Sort;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefBuilder;
 import org.apache.lucene.util.CharsRefBuilder;
@@ -43,6 +44,7 @@ import org.apache.solr.request.BidirectionalFacetResponseBuilder.AscendingFacetT
 import org.apache.solr.request.BidirectionalFacetResponseBuilder.DescendingFacetTermIteratorFactory;
 import org.apache.solr.request.BidirectionalFacetResponseBuilder.Env;
 import org.apache.solr.request.BidirectionalFacetResponseBuilder.LocalTermEnv;
+import org.apache.solr.request.DocBasedFacetResponseBuilder.LocalDocEnv;
 import org.apache.solr.schema.FieldType;
 import org.apache.solr.schema.SchemaField;
 import org.apache.solr.search.DocSet;
@@ -253,8 +255,14 @@ public class DocValuesFacets {
         }
         } else {
           final int targetIdx = (int)si.lookupTerm(target);
-          Env env = new LocalTermEnv(offset, limit, startTermIndex, adjust, targetIdx, targetDoc, nTerms, contains,
-              ignoreCase, mincount, counts, charsRef, extend, si, searcher, fieldName, ft, res);
+          Env env;
+          if (targetDoc != null) {
+            env = new LocalDocEnv(offset, limit, startTermIndex, adjust, targetIdx, targetDoc, nTerms, contains,
+                ignoreCase, mincount, counts, charsRef, extend, si, searcher, docs, fieldName, ft, res);
+          } else {
+            env = new LocalTermEnv(offset, limit, startTermIndex, adjust, targetIdx, nTerms, contains,
+                ignoreCase, mincount, counts, charsRef, extend, si, searcher, fieldName, ft, res);
+          }
           BidirectionalFacetResponseBuilder.build(env, new DescendingFacetTermIteratorFactory(),
               new AscendingFacetTermIteratorFactory());
         }

--- a/src/main/java/org/apache/solr/request/MultiSerializable.java
+++ b/src/main/java/org/apache/solr/request/MultiSerializable.java
@@ -43,4 +43,6 @@ public interface MultiSerializable {
   void updateExternalRepresentation(NamedList<Object> nl);
 
   BytesRef normalizeQueryTarget(String val, boolean strict, String fieldName) throws IOException;
+
+  String getDelim();
 }

--- a/src/main/java/org/apache/solr/request/SimpleFacets.java
+++ b/src/main/java/org/apache/solr/request/SimpleFacets.java
@@ -424,8 +424,13 @@ public class SimpleFacets {
     String targetDoc = null;
     BytesRef targetBr = null;
     if (target != null) {
-      boolean targetStrict = params.getFieldBool(field, FacetParams.FACET_TARGET_STRICT, false);
       targetDoc = params.getFieldParam(field, FacetParams.FACET_TARGET_DOC);
+      boolean targetStrict;
+      if (targetDoc != null) {
+        targetStrict = true;
+      } else {
+        targetStrict = params.getFieldBool(field, FacetParams.FACET_TARGET_STRICT, false);
+      }
       if (ft instanceof MultiSerializable) {
         targetBr = ((MultiSerializable)ft).normalizeQueryTarget(target, targetStrict, field);
       } else {

--- a/src/test/java/org/apache/solr/request/BidirectionalFacetResponseBuilderTest.java
+++ b/src/test/java/org/apache/solr/request/BidirectionalFacetResponseBuilderTest.java
@@ -22,8 +22,6 @@ import java.util.Arrays;
 import java.util.Deque;
 import java.util.Map;
 import org.apache.solr.common.util.NamedList;
-import org.apache.solr.request.BidirectionalFacetResponseBuilder.AscendingFacetTermIteratorFactory;
-import org.apache.solr.request.BidirectionalFacetResponseBuilder.DescendingFacetTermIteratorFactory;
 import org.apache.solr.request.BidirectionalFacetResponseBuilder.Env;
 import org.apache.solr.request.BidirectionalFacetResponseBuilder.SimpleTermIndexKey;
 import org.apache.solr.schema.FieldType;
@@ -137,8 +135,7 @@ public class BidirectionalFacetResponseBuilderTest<T extends FieldType & FacetPa
     NamedList exp = buildExpected(expectedOffset, expectedIndices);
     NamedList actual = new NamedList(3);
     Env<T, SimpleTermIndexKey> env = new TestEnv<>(requestedOffset, limit, targetIdx, mincount, fieldName, ft, actual, counts);
-    BidirectionalFacetResponseBuilder.build(env, new DescendingFacetTermIteratorFactory(),
-              new AscendingFacetTermIteratorFactory());
+    BidirectionalFacetResponseBuilder.build(env, false);
     assertEquals(actual.get("count"), ((NamedList)actual.get("terms")).size());
     assertEquals(exp, actual);
   }
@@ -223,7 +220,5 @@ public class BidirectionalFacetResponseBuilderTest<T extends FieldType & FacetPa
     public void initState(SimpleTermIndexKey key) {
       // stub
     }
-
   }
-  
 }

--- a/src/test/java/org/apache/solr/request/BidirectionalFacetResponseBuilderTest.java
+++ b/src/test/java/org/apache/solr/request/BidirectionalFacetResponseBuilderTest.java
@@ -219,6 +219,11 @@ public class BidirectionalFacetResponseBuilderTest<T extends FieldType & FacetPa
       return counts[i] >= mincount;
     }
 
+    @Override
+    public void initState(SimpleTermIndexKey key) {
+      // stub
+    }
+
   }
   
 }

--- a/src/test/java/org/apache/solr/request/BidirectionalFacetResponseBuilderTest.java
+++ b/src/test/java/org/apache/solr/request/BidirectionalFacetResponseBuilderTest.java
@@ -136,7 +136,7 @@ public class BidirectionalFacetResponseBuilderTest<T extends FieldType & FacetPa
     T ft = null;
     NamedList exp = buildExpected(expectedOffset, expectedIndices);
     NamedList actual = new NamedList(3);
-    Env<T, SimpleTermIndexKey> env = new TestEnv<>(requestedOffset, limit, targetIdx, targetDoc, mincount, fieldName, ft, actual, counts);
+    Env<T, SimpleTermIndexKey> env = new TestEnv<>(requestedOffset, limit, targetIdx, mincount, fieldName, ft, actual, counts);
     BidirectionalFacetResponseBuilder.build(env, new DescendingFacetTermIteratorFactory(),
               new AscendingFacetTermIteratorFactory());
     assertEquals(actual.get("count"), ((NamedList)actual.get("terms")).size());
@@ -161,8 +161,8 @@ public class BidirectionalFacetResponseBuilderTest<T extends FieldType & FacetPa
 
     private final int[] counts;
     
-    public TestEnv(int offset, int limit, int targetIdx, String targetDoc, int mincount, String fieldName, T ft, NamedList res, int[] counts) {
-      super(offset, limit, targetIdx, targetDoc, mincount, fieldName, ft, res);
+    public TestEnv(int offset, int limit, int targetIdx, int mincount, String fieldName, T ft, NamedList res, int[] counts) {
+      super(offset, limit, targetIdx, mincount, fieldName, ft, res);
       this.counts = counts;
     }
     


### PR DESCRIPTION
Adds functionality to view term index browse results (incl. targets and offsets) with respect to documents. This effectively implements multivalued sorting.
