### PR TITLE
debug/enhance extended facet count handling (incl. respect deleted docs)

### DIFF
--- a/src/main/java/edu/upenn/library/solrplugins/CaseInsensitiveSortingTextField.java
+++ b/src/main/java/edu/upenn/library/solrplugins/CaseInsensitiveSortingTextField.java
@@ -26,6 +26,7 @@ import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
 import org.apache.lucene.analysis.tokenattributes.TypeAttribute;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.PostingsEnum;
+import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefBuilder;
 import org.apache.lucene.util.CharsRef;
@@ -224,13 +225,13 @@ public class CaseInsensitiveSortingTextField extends TextField implements MultiS
   }
 
   @Override
-  public boolean addEntry(String termKey, long count, PostingsEnum postings, NamedList res) throws IOException {
-    return payloadHandler.addEntry(termKey, count, postings, res);
+  public boolean addEntry(String termKey, long count, PostingsEnum postings, Bits liveDocs, NamedList res) throws IOException {
+    return payloadHandler.addEntry(termKey, count, postings, liveDocs, res);
   }
 
   @Override
-  public Entry<String, Object> addEntry(String termKey, long count, PostingsEnum postings) throws IOException {
-    return payloadHandler.addEntry(termKey, count, postings);
+  public Entry<String, Object> addEntry(String termKey, long count, PostingsEnum postings, Bits liveDocs) throws IOException {
+    return payloadHandler.addEntry(termKey, count, postings, liveDocs);
   }
 
   @Override
@@ -251,12 +252,12 @@ public class CaseInsensitiveSortingTextField extends TextField implements MultiS
   private static class DefaultPayloadHandler implements FacetPayload<Object> {
 
     @Override
-    public boolean addEntry(String termKey, long count, PostingsEnum postings, NamedList<Object> res) throws IOException {
+    public boolean addEntry(String termKey, long count, PostingsEnum postings, Bits liveDocs, NamedList<Object> res) throws IOException {
       return false;
     }
 
     @Override
-    public Entry<String, Object> addEntry(String termKey, long count, PostingsEnum postings) throws IOException {
+    public Entry<String, Object> addEntry(String termKey, long count, PostingsEnum postings, Bits liveDocs) throws IOException {
       return null;
     }
 

--- a/src/main/java/org/apache/solr/request/BidirectionalFacetResponseBuilder.java
+++ b/src/main/java/org/apache/solr/request/BidirectionalFacetResponseBuilder.java
@@ -21,9 +21,11 @@ import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.Map.Entry;
+import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.PostingsEnum;
 import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.index.Term;
+import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.CharsRefBuilder;
 import org.apache.solr.common.SolrDocument;
@@ -845,8 +847,10 @@ public class BidirectionalFacetResponseBuilder<T extends FieldType & FacetPayloa
       if (!extend) {
         entry = new SimpleImmutableEntry<>(currentTerm, currentTermCount);
       } else {
-        PostingsEnum postings = searcher.getSlowAtomicReader().postings(new Term(fieldName, currentTermBytes), PostingsEnum.PAYLOADS);
-        if ((entry = ft.addEntry(currentTerm, currentTermCount, postings)) == null) {
+        LeafReader slowAtomicReader = searcher.getSlowAtomicReader();
+        Bits liveDocs = slowAtomicReader.getLiveDocs();
+        PostingsEnum postings = slowAtomicReader.postings(new Term(fieldName, currentTermBytes), PostingsEnum.PAYLOADS);
+        if ((entry = ft.addEntry(currentTerm, currentTermCount, postings, liveDocs)) == null) {
           entry = new SimpleImmutableEntry<>(currentTerm, currentTermCount);
         }
       }

--- a/src/main/java/org/apache/solr/request/DocBasedFacetResponseBuilder.java
+++ b/src/main/java/org/apache/solr/request/DocBasedFacetResponseBuilder.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import org.apache.lucene.document.Document;
+import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.PostingsEnum;
 import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.index.Term;
@@ -34,6 +35,7 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.CharsRefBuilder;
 import org.apache.lucene.util.UnicodeUtil;
@@ -254,8 +256,10 @@ public class DocBasedFacetResponseBuilder {
         docDeque.add(new SimpleImmutableEntry<>(docIdStr, doc));
         NamedList<Object> termEntry = new NamedList<>(4);
         if (extend) {
-          PostingsEnum postings = searcher.getSlowAtomicReader().postings(new Term(fieldName, currentTermBytes), PostingsEnum.PAYLOADS);
-          Entry<String, Object> entry = ft.addEntry(currentTerm, currentTermCount, postings);
+          LeafReader slowAtomicReader = searcher.getSlowAtomicReader();
+          Bits liveDocs = slowAtomicReader.getLiveDocs();
+          PostingsEnum postings = slowAtomicReader.postings(new Term(fieldName, currentTermBytes), PostingsEnum.PAYLOADS);
+          Entry<String, Object> entry = ft.addEntry(currentTerm, currentTermCount, postings, liveDocs);
           if (entry != null) {
             termEntry.add("termMetadata", entry.getValue());
           }

--- a/src/main/java/org/apache/solr/request/FacetPayload.java
+++ b/src/main/java/org/apache/solr/request/FacetPayload.java
@@ -19,6 +19,7 @@ package org.apache.solr.request;
 import java.io.IOException;
 import java.util.Map.Entry;
 import org.apache.lucene.index.PostingsEnum;
+import org.apache.lucene.util.Bits;
 import org.apache.solr.common.util.NamedList;
 
 /**
@@ -27,8 +28,8 @@ import org.apache.solr.common.util.NamedList;
  */
 public interface FacetPayload<T> {
   long extractCount(T val);
-  boolean addEntry(String termKey, long count, PostingsEnum postings, NamedList<T> res) throws IOException;
-  Entry<String, T> addEntry(String termKey, long count, PostingsEnum postings) throws IOException;
+  boolean addEntry(String termKey, long count, PostingsEnum postings, Bits liveDocs, NamedList<T> res) throws IOException;
+  Entry<String, T> addEntry(String termKey, long count, PostingsEnum postings, Bits liveDocs) throws IOException;
   T mergePayload(T preExisting, T add, long preExistingCount, long addCount);
   Object updateValueExternalRepresentation(T internal);
 }


### PR DESCRIPTION
Mostly changes to get facet counts to respect deleted documents. One other change, in JsonReferencePayloadHandler line 206, changed `.remove()` to `.get()` to avoid unintended side-effects (the side-effects are unintended from my perspective ;-) -- was throwing NPE at some point -- so please let me know if I need to rethink this).