### PR TITLE
check liveDocs == null, which can happen when reindexing docs

### DIFF
--- a/src/main/java/edu/upenn/library/solrplugins/JsonReferencePayloadHandler.java
+++ b/src/main/java/edu/upenn/library/solrplugins/JsonReferencePayloadHandler.java
@@ -154,7 +154,7 @@ public class JsonReferencePayloadHandler implements FacetPayload<NamedList<Objec
     NamedList<Object> refs = new NamedList<>();
 
     while (postings.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
-      if (!liveDocs.get(postings.docID())) {
+      if (liveDocs == null || !liveDocs.get(postings.docID())) {
         continue;
       }
       for (int j = 0; j < postings.freq(); j++) {


### PR DESCRIPTION
This fixes a NPE that can happen when you reindex documents without deleting them first, because of the way Solr stores information in segments. For reference, this is the error message and stack trace:

```
2017-01-20 16:20:01.889 ERROR (qtp1528637575-20) [   x:blacklight-core] o.a.s.s.HttpSolrCall null:org.apache.solr.common.SolrException: Exception during facet.field: title_xfacet
	at org.apache.solr.request.SimpleFacets.lambda$getFacetFieldCounts$0(SimpleFacets.java:791)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at org.apache.solr.common.util.ExecutorUtil$MDCAwareThreadPoolExecutor.lambda$execute$0(ExecutorUtil.java:229)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Caused by: java.lang.NullPointerException
	at edu.upenn.library.solrplugins.JsonReferencePayloadHandler.buildEntryValue(JsonReferencePayloadHandler.java:157)
	at edu.upenn.library.solrplugins.JsonReferencePayloadHandler.addEntry(JsonReferencePayloadHandler.java:127)
	at edu.upenn.library.solrplugins.CaseInsensitiveSortingTextField.addEntry(CaseInsensitiveSortingTextField.java:234)
	at org.apache.solr.request.DocValuesFacets.addEntry(DocValuesFacets.java:292)
	at org.apache.solr.request.DocValuesFacets.getCounts(DocValuesFacets.java:219)
	at org.apache.solr.request.SimpleFacets.getTermCounts(SimpleFacets.java:555)
	at org.apache.solr.request.SimpleFacets.getTermCounts(SimpleFacets.java:386)
	at org.apache.solr.request.SimpleFacets.lambda$getFacetFieldCounts$0(SimpleFacets.java:785)
	... 5 more
```